### PR TITLE
don’t create empty elements

### DIFF
--- a/src/DomDocuments/CustomersDocument.php
+++ b/src/DomDocuments/CustomersDocument.php
@@ -67,14 +67,16 @@ class CustomersDocument extends \DOMDocument
         foreach ($customerTags as $tag => $method) {
 
             // Make text node for method value
-            $node = $this->createTextNode($customer->$method());
+            if($customer->$method()) {
+                $node = $this->createTextNode($customer->$method());
 
-            // Make the actual element and assign the node
-            $element = $this->createElement($tag);
-            $element->appendChild($node);
+                // Make the actual element and assign the node
+                $element = $this->createElement($tag);
+                $element->appendChild($node);
 
-            // Add the full element
-            $this->dimensionElement->appendChild($element);
+                // Add the full element
+                $this->dimensionElement->appendChild($element);
+            }
         }
 
         // Check if the financial information should be supplied

--- a/tests/IntegrationTests/resources/customerSendRequest.xml
+++ b/tests/IntegrationTests/resources/customerSendRequest.xml
@@ -1,5 +1,4 @@
-<dimension>
-    <code/>
+<dimension>    
     <name>Customer 0</name>
     <type>DEB</type>
     <website></website>

--- a/tests/IntegrationTests/resources/customerSendRequest.xml
+++ b/tests/IntegrationTests/resources/customerSendRequest.xml
@@ -1,7 +1,6 @@
 <dimension>    
     <name>Customer 0</name>
     <type>DEB</type>
-    <website></website>
     <office>001</office>
     <financials>
         <duedays>30</duedays>


### PR DESCRIPTION
if you don’t specify a < code > element, twinfield will automatically generate a new code according to the administration it’s mask. If you specify < code > Twinfield will actually say that code is required. If you don't pass in the element at all the code will be automatically generated.

getFirstFreeCode is unreliable as administrations can use different masks. It will also not work on administration with multiple (legacy) ranges

I have a lot of fixes and new functionalities for this library. I also improved the OAuth library because right now it is dependant on a $_SESSION. If you use something else for your intermediate token storage (for instance a framework for session management) this won't work

Also you maybe should remove the password authentication part from the documentation because this is officially deprecated by Twinfield

I also implemented OAuth V2.0 for this library (this just in by Twinfield). Next week I will make some new pull requests if I get around to it