### PR TITLE
Adds performanceType to SalesInvoiceLines

### DIFF
--- a/src/DomDocuments/InvoicesDocument.php
+++ b/src/DomDocuments/InvoicesDocument.php
@@ -98,6 +98,7 @@ class InvoicesDocument extends BaseDocument
             'freetext2'       => 'getFreeText2',
             'freetext3'       => 'getFreeText3',
             'performancedate' => 'getPerformanceDate',
+            'performancetype' => 'getPerformanceType',
             'dim1'            => 'getDim1',
         );
 

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -1,6 +1,7 @@
 <?php
 namespace PhpTwinfield;
 
+use PhpTwinfield\Enums\PerformanceType;
 use PhpTwinfield\Transactions\TransactionFields\FreeTextFields;
 use PhpTwinfield\Transactions\TransactionLineFields\VatCodeField;
 
@@ -26,8 +27,12 @@ class InvoiceLine
     private $vatValue;
     private $valueInc;
     private $performanceDate;
-    private $performanceType;
     private $dim1;
+
+    /**
+     * @var PerformanceType|null Mandatory in case of an ICT VAT code.
+     */
+    private $performanceType;
 
     public function __construct($quantity = null, $article = null, $freeText1 = null, $freeText2 = null)
     {
@@ -182,12 +187,12 @@ class InvoiceLine
         return $this;
     }
 
-    public function getPerformanceType()
+    public function getPerformanceType(): ?PerformanceType
     {
         return $this->performanceType;
     }
 
-    public function setPerformanceType($performanceType)
+    public function setPerformanceType(?PerformanceType $performanceType): self
     {
         $this->performanceType = $performanceType;
         return $this;

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -26,6 +26,7 @@ class InvoiceLine
     private $vatValue;
     private $valueInc;
     private $performanceDate;
+    private $performanceType;
     private $dim1;
 
     public function __construct($quantity = null, $article = null, $freeText1 = null, $freeText2 = null)
@@ -178,6 +179,17 @@ class InvoiceLine
     public function setPerformanceDate($performanceDate)
     {
         $this->performanceDate = $performanceDate;
+        return $this;
+    }
+
+    public function getPerformanceType()
+    {
+        return $this->performanceType;
+    }
+
+    public function setPerformanceType($performanceType)
+    {
+        $this->performanceType = $performanceType;
         return $this;
     }
 

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -92,6 +92,7 @@ class InvoiceMapper
             'freetext2'              => 'setFreeText2',
             'freetext3'              => 'setFreeText3',
             'performancedate'        => 'setPerformanceDate',
+            'performancetype'        => 'setPerformanceType',
             'dim1'                   => 'setDim1',
         );
 

--- a/tests/IntegrationTests/resources/invoiceSendRequest.xml
+++ b/tests/IntegrationTests/resources/invoiceSendRequest.xml
@@ -30,6 +30,7 @@
                 <freetext2></freetext2>
                 <freetext3></freetext3>
                 <performancedate></performancedate>
+                <performancetype></performancetype>
                 <dim1>8020</dim1>
             </line>
         </lines>


### PR DESCRIPTION
Adds the attribute performanceType for InvoiceLines as documented: https://c3.twinfield.com/webservices/documentation/#/ApiReference/SalesInvoices

Copied over from our [fork](https://github.com/picqer/twinfield-php-client/commit/32a6a859f9e1a21e7b05e6b302157751254300b2) which we are already using for quite some time and will abandon when this one is up to speed :)
  