### PR TITLE
Return the mapped invoice object from twinfield

### DIFF
--- a/src/ApiConnectors/InvoiceApiConnector.php
+++ b/src/ApiConnectors/InvoiceApiConnector.php
@@ -52,16 +52,16 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
      * @param Invoice $invoice
      * @throws Exception
      */
-    public function send(Invoice $invoice): void
+    public function send(Invoice $invoice)
     {
-        $this->sendAll([$invoice]);
+        return $this->sendAll([$invoice]);
     }
 
     /**
      * @param Invoice[] $invoices
      * @throws Exception
      */
-    public function sendAll(array $invoices): void
+    public function sendAll(array $invoices)
     {
         Assert::allIsInstanceOf($invoices, Invoice::class);
 
@@ -73,7 +73,9 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
                 $invoicesDocument->addInvoice($invoice);
             }
 
-            $this->sendDocument($invoicesDocument);
+            $response = $this->sendDocument($invoicesDocument);
+			
+            return InvoiceMapper::map($response);
         }
     }
 }

--- a/src/ApiConnectors/InvoiceApiConnector.php
+++ b/src/ApiConnectors/InvoiceApiConnector.php
@@ -55,7 +55,8 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
      */
     public function send(Invoice $invoice): Invoice
     {
-        return reset($this->sendAll([$invoice]));
+        $result = $this->sendAll([$invoice]);
+        return reset($result);
     }
 
     /**
@@ -66,6 +67,7 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
     public function sendAll(array $invoices): array
     {
         Assert::allIsInstanceOf($invoices, Invoice::class);
+        $arrInvoices = [];
 
         foreach ($this->chunk($invoices) as $chunk) {
 
@@ -77,7 +79,9 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
 
             $response = $this->sendDocument($invoicesDocument);
 
-            return InvoiceMapper::map($response);
+            array_push($arrInvoices, InvoiceMapper::map($response));
+
         }
+        return $arrInvoices;
     }
 }

--- a/src/ApiConnectors/InvoiceApiConnector.php
+++ b/src/ApiConnectors/InvoiceApiConnector.php
@@ -31,7 +31,7 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
      * @return Invoice|bool The requested invoice or false if it can't be found.
      * @throws Exception
      */
-    public function get(string $code, string $invoiceNumber, Office $office)
+    public function get(string $code, string $invoiceNumber, Office $office): Invoice
     {
         // Make a request to read a single invoice. Set the required values
         $request_invoice = new Request\Read\Invoice();
@@ -53,17 +53,17 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
      * @return Invoice The processed invoice from Twinfield
      * @throws Exception
      */
-    public function send(Invoice $invoice)
+    public function send(Invoice $invoice): Invoice
     {
-        return $this->sendAll([$invoice]);
+        return reset($this->sendAll([$invoice]));
     }
 
     /**
      * @param Invoice[] $invoices
-     * @return Invoice The processed invoice from Twinfield
+     * @return Invoice[] The processed invoices from Twinfield
      * @throws Exception
      */
-    public function sendAll(array $invoices)
+    public function sendAll(array $invoices): array
     {
         Assert::allIsInstanceOf($invoices, Invoice::class);
 
@@ -76,7 +76,7 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
             }
 
             $response = $this->sendDocument($invoicesDocument);
-			
+
             return InvoiceMapper::map($response);
         }
     }

--- a/src/ApiConnectors/InvoiceApiConnector.php
+++ b/src/ApiConnectors/InvoiceApiConnector.php
@@ -50,6 +50,7 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
      * Sends a \PhpTwinfield\Invoice\Invoice instance to Twinfield to update or add.
      *
      * @param Invoice $invoice
+     * @return Invoice The processed invoice from Twinfield
      * @throws Exception
      */
     public function send(Invoice $invoice)
@@ -59,6 +60,7 @@ class InvoiceApiConnector extends ProcessXmlApiConnector
 
     /**
      * @param Invoice[] $invoices
+     * @return Invoice The processed invoice from Twinfield
      * @throws Exception
      */
     public function sendAll(array $invoices)

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -36,7 +36,15 @@ class Invoice
     private $invoiceNumber;
     private $status;
     private $currency;
+
+    /**
+     * @var \DateTimeInterface
+     */
     private $invoiceDate;
+
+    /**
+     * @var \DateTimeInterface
+     */
     private $performanceDate;
     private $paymentMethod;
     private $bank;
@@ -145,23 +153,37 @@ class Invoice
         return $this;
     }
 
-    public function getInvoiceDate()
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getInvoiceDate(): \DateTimeInterface
     {
         return $this->invoiceDate;
     }
 
-    public function setInvoiceDate($invoiceDate)
+    /**
+     * @param \DateTimeInterface $invoiceDate
+     * @return $this
+     */
+    public function setInvoiceDate(\DateTimeInterface $invoiceDate)
     {
         $this->invoiceDate = $invoiceDate;
         return $this;
     }
 
-    public function getPerformanceDate()
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getPerformanceDate(): \DateTimeInterface
     {
         return $this->performanceDate;
     }
 
-    public function setPerformanceDate($performanceDate)
+    /**
+     * @param \DateTimeInterface $performanceDate
+     * @return $this
+     */
+    public function setPerformanceDate(\DateTimeInterface $performanceDate)
     {
         $this->performanceDate = $performanceDate;
         return $this;

--- a/src/Mappers/BaseMapper.php
+++ b/src/Mappers/BaseMapper.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PhpTwinfield\Mappers;
+
+use MyCLabs\Enum\Enum;
+use PhpTwinfield\Util;
+
+abstract class BaseMapper
+{
+    /**
+     * Set a property on an object using a setter from a tag within the element.
+     *
+     * @param \DOMNode $node
+     * @param string $tag
+     * @param callable $setter Must be in the array($object, $method) syntax where method takes one argument.
+     */
+    protected static function setFromTagUsingCallable(\DOMNode $node, string $tag, callable $setter): void
+    {
+        /** @var \DOMNode|\DOMDocument $node */
+        $element = $node->getElementsByTagName($tag)->item(0);
+
+        if (empty($element)) {
+            return;
+        }
+
+        $contents = $element->textContent;
+
+        if ($contents === null) {
+            return;
+        }
+
+        $contents = self::transformContent(new \ReflectionMethod(...$setter), $contents);
+
+        call_user_func($setter, $contents);
+    }
+
+    private static function transformContent(\ReflectionMethod $reflectionMethod, string $contents)
+    {
+        [$parameter] = $reflectionMethod->getParameters();
+
+        if ($parameter->getType() === null) {
+            /*
+             * No typehint, just return the string.
+             */
+            return $contents;
+        }
+
+        $parameter_class = $parameter->getType()->getName();
+
+        if (is_subclass_of($parameter_class, Enum::class)) {
+            return new $parameter_class($contents);
+        }
+
+        if ($parameter_class == \DateTimeInterface::class) {
+            return Util::parseDate($contents);
+        }
+
+        return $contents;
+    }
+}

--- a/src/Mappers/BaseMapper.php
+++ b/src/Mappers/BaseMapper.php
@@ -25,7 +25,7 @@ abstract class BaseMapper
 
         $contents = $element->textContent;
 
-        if ($contents === null) {
+        if ($contents === null || empty($contents)) {
             return;
         }
 

--- a/src/Mappers/BaseMapper.php
+++ b/src/Mappers/BaseMapper.php
@@ -25,7 +25,7 @@ abstract class BaseMapper
 
         $contents = $element->textContent;
 
-        if ($contents === null || empty($contents)) {
+        if ($contents === null) {
             return;
         }
 
@@ -51,7 +51,7 @@ abstract class BaseMapper
             return new $parameter_class($contents);
         }
 
-        if ($parameter_class == \DateTimeInterface::class) {
+        if ($parameter_class == \DateTimeInterface::class && !empty($contents)) {
             return Util::parseDate($contents);
         }
 

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -104,7 +104,7 @@ class InvoiceMapper
             foreach ($lineTags as $tag => $method) {
                 $_tag = $lineDOM->getElementsByTagName($tag)->item(0);
 
-                if (isset($_tag) && isset($_tag->textContent)) {
+                if (isset($_tag) && !empty($_tag->textContent)) {
                     $temp_line->$method($_tag->textContent);
                 }
             }

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -104,7 +104,10 @@ class InvoiceMapper
             foreach ($lineTags as $tag => $method) {
                 $_tag = $lineDOM->getElementsByTagName($tag)->item(0);
 
-                if (isset($_tag) && !empty($_tag->textContent)) {
+                if (isset($_tag) && isset($_tag->textContent)) {
+                    if ($_tag == 'performancetype' && empty($_tag->textContent)) {
+                        continue;
+                    }
                     $temp_line->$method($_tag->textContent);
                 }
             }

--- a/tests/IntegrationTests/InvoiceIntegrationTest.php
+++ b/tests/IntegrationTests/InvoiceIntegrationTest.php
@@ -105,7 +105,7 @@ class InvoiceIntegrationTest extends BaseIntegrationTest
         $invoice->setOffice('11024');
         $invoice->setInvoiceType('FACTUUR');
         $invoice->setInvoiceNumber('5');
-        $invoice->setInvoiceDate('20120831');
+        $invoice->setInvoiceDate(new \DateTimeImmutable('2012-08-31'));
         $invoice->setBank('BNK');
         $invoice->setInvoiceAddressNumber('1');
         $invoice->setDeliverAddressNumber('1');

--- a/tests/IntegrationTests/InvoiceIntegrationTest.php
+++ b/tests/IntegrationTests/InvoiceIntegrationTest.php
@@ -4,6 +4,7 @@ namespace PhpTwinfield\IntegrationTests;
 
 use PhpTwinfield\ApiConnectors\InvoiceApiConnector;
 use PhpTwinfield\Customer;
+use PhpTwinfield\Enums\PerformanceType;
 use PhpTwinfield\Invoice;
 use PhpTwinfield\DomDocuments\InvoicesDocument;
 use PhpTwinfield\InvoiceLine;
@@ -53,7 +54,7 @@ class InvoiceIntegrationTest extends BaseIntegrationTest
         $this->assertSame('11024', $invoice->getOffice());
         $this->assertSame('FACTUUR', $invoice->getInvoiceType());
         $this->assertSame('5', $invoice->getInvoiceNumber());
-        $this->assertSame('20120831', $invoice->getInvoiceDate());
+        $this->assertEquals(new \DateTimeImmutable('2012-08-31'), $invoice->getInvoiceDate());
         $this->assertSame('BNK', $invoice->getBank());
         $this->assertSame('1', $invoice->getInvoiceAddressNumber());
         $this->assertSame('1', $invoice->getDeliverAddressNumber());
@@ -87,6 +88,7 @@ class InvoiceIntegrationTest extends BaseIntegrationTest
         $this->assertSame('', $invoiceLine->getFreeText2());
         $this->assertSame('', $invoiceLine->getFreeText3());
         $this->assertSame('8020', $invoiceLine->getDim1());
+        $this->assertEquals(PerformanceType::SERVICES(), $invoiceLine->getPerformanceType());
 
         // TODO - Vat lines
 

--- a/tests/IntegrationTests/resources/invoiceGetResponse.xml
+++ b/tests/IntegrationTests/resources/invoiceGetResponse.xml
@@ -34,13 +34,15 @@
             <freetext3/>
             <dim1>8020</dim1>
             <vatcode name="BTW 0%" shortname="V 0%" type="sales">VN</vatcode>
+            <performancetype>services</performancetype>
         </line>
     </lines>
     <vatlines>
         <vatline>
             <vatcode name="BTW 0%">VN</vatcode>
             <vatvalue>0.00</vatvalue>
-            <performancetype/><performancedate/>
+            <performancetype/>
+            <performancedate>20120831</performancedate>
         </vatline>
     </vatlines>
     <totals>


### PR DESCRIPTION
I had to change the Invoicemapper from isset to !empty.
Otherwise it will execute the setPerformanceType, which gets an empty string as input but it expects an ENUM of type PerformanceType

Fix for issue #52 
  