### PR TITLE
DebitCredit field is wrong for lines of 'total' type, fixes #25

### DIFF
--- a/src/BankTransaction.php
+++ b/src/BankTransaction.php
@@ -107,7 +107,7 @@ class BankTransaction implements Transaction
          */
         $this->traitAddLine($line);
 
-        if (!$line->getType()->equals(LineType::TOTAL())) {
+        if (!$line->getLineType()->equals(LineType::TOTAL())) {
             /*
              * Don't add total lines to the closevalue, they are summaries of the details and vat lines.
              *

--- a/src/BaseTransactionLine.php
+++ b/src/BaseTransactionLine.php
@@ -9,7 +9,6 @@ use PhpTwinfield\Transactions\TransactionLineFields\CommentField;
 use PhpTwinfield\Transactions\TransactionLineFields\ThreeDimFields;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueFields;
 use PhpTwinfield\Transactions\TransactionLineFields\VatTurnoverFields;
-use Webmozart\Assert\Assert;
 
 /**
  * @todo $relation Only if line type is total (or detail for Journal transactions). Read-only attribute.
@@ -42,7 +41,7 @@ abstract class BaseTransactionLine implements TransactionLine
     /**
      * @var LineType
      */
-    protected $type;
+    protected $lineType;
 
     /**
      * @var int|null The line ID.
@@ -111,18 +110,18 @@ abstract class BaseTransactionLine implements TransactionLine
      */
     protected $vatValue;
 
-    public function getType(): LineType
+    public function getLineType(): LineType
     {
-        return $this->type;
+        return $this->lineType;
     }
 
     /**
-     * @param LineType $type
+     * @param LineType $lineType
      * @return $this
      */
-    public function setType(LineType $type): BaseTransactionLine
+    public function setLineType(LineType $lineType): BaseTransactionLine
     {
-        $this->type = $type;
+        $this->lineType = $lineType;
 
         return $this;
     }
@@ -313,7 +312,7 @@ abstract class BaseTransactionLine implements TransactionLine
      */
     public function setVatCode(?string $vatCode): BaseTransactionLine
     {
-        if ($vatCode !== null && !in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()])) {
+        if ($vatCode !== null && !in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()])) {
             throw Exception::invalidFieldForLineType('vatCode', $this);
         }
 
@@ -337,7 +336,7 @@ abstract class BaseTransactionLine implements TransactionLine
      */
     public function setVatValue(?Money $vatValue): BaseTransactionLine
     {
-        if ($vatValue !== null && !$this->getType()->equals(LineType::DETAIL())) {
+        if ($vatValue !== null && !$this->getLineType()->equals(LineType::DETAIL())) {
             throw Exception::invalidFieldForLineType('vatValue', $this);
         }
 

--- a/src/DomDocuments/BankTransactionDocument.php
+++ b/src/DomDocuments/BankTransactionDocument.php
@@ -84,7 +84,7 @@ class BankTransactionDocument extends BaseDocument
     protected function createTransactionLineElement(BankTransactionLine\Base $line): \DOMElement
     {
         $transaction = $this->createElement("line");
-        $transaction->appendChild(new \DOMAttr("type", $line->getType()));
+        $transaction->appendChild(new \DOMAttr("type", $line->getLineType()));
 
         if ($line->getId() !== null) {
             $transaction->appendChild(new \DOMAttr("id", $line->getId()));

--- a/src/DomDocuments/TransactionsDocument.php
+++ b/src/DomDocuments/TransactionsDocument.php
@@ -105,7 +105,7 @@ class TransactionsDocument extends BaseDocument
         /** @var BaseTransactionLine $transactionLine */
         foreach ($transaction->getLines() as $transactionLine) {
             $lineElement = $this->createElement('line');
-            $lineElement->setAttribute('type', $transactionLine->getType());
+            $lineElement->setAttribute('type', $transactionLine->getLineType());
             $lineElement->setAttribute('id', $transactionLine->getId());
             $linesElement->appendChild($lineElement);
 
@@ -169,7 +169,7 @@ class TransactionsDocument extends BaseDocument
 
             if (
                 $transactionLine instanceof JournalTransactionLine &&
-                $transactionLine->getType() == 'detail' &&
+                $transactionLine->getLineType() == 'detail' &&
                 $transactionLine->getInvoiceNumber() !== null
             ) {
                 $invoiceNumberElement = $this->createElement('invoicenumber', $transactionLine->getInvoiceNumber());
@@ -183,7 +183,7 @@ class TransactionsDocument extends BaseDocument
                 $lineElement->appendChild($descriptionElement);
             }
 
-            if ($transactionLine->getType() != 'total' && $transactionLine->getVatCode() !== null) {
+            if ($transactionLine->getLineType() != 'total' && $transactionLine->getVatCode() !== null) {
                 $vatCodeElement = $this->createElement('vatcode', $transactionLine->getVatCode());
                 $lineElement->appendChild($vatCodeElement);
             }

--- a/src/ElectronicBankStatementTransaction.php
+++ b/src/ElectronicBankStatementTransaction.php
@@ -2,8 +2,6 @@
 
 namespace PhpTwinfield;
 
-use Money\Money;
-use PhpTwinfield\Enums\DebitCredit;
 use PhpTwinfield\Transactions\TransactionLineFields\FourDimFields;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueFields;
 

--- a/src/ElectronicBankStatementTransaction.php
+++ b/src/ElectronicBankStatementTransaction.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield;
 
+use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\Transactions\TransactionLineFields\FourDimFields;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueFields;
 
@@ -91,5 +92,13 @@ class ElectronicBankStatementTransaction
     public function setDescription(string $description): void
     {
         $this->description = $description;
+    }
+
+    public function getLineType(): ?LineType
+    {
+        /*
+         * Electronic bank statement transactions don't have line types.
+         */
+        return null;
     }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -35,7 +35,7 @@ class Exception extends \Exception
             "Dimension %d is invalid for line class %s and type '%s'.",
             $dimensionNumber,
             get_class($transactionLine),
-            $transactionLine->getType()
+            $transactionLine->getLineType()
         ));
     }
 
@@ -45,7 +45,7 @@ class Exception extends \Exception
             "Invalid field '%s' for line class %s and type '%s'.",
             $fieldName,
             get_class($transactionLine),
-            $transactionLine->getType()
+            $transactionLine->getLineType()
         ));
     }
 
@@ -57,7 +57,7 @@ class Exception extends \Exception
             "Invalid match status '%s' for line class %s and type '%s'.",
             $matchStatus,
             get_class($transactionLine),
-            $transactionLine->getType()
+            $transactionLine->getLineType()
         ));
     }
 }

--- a/src/JournalTransactionLine.php
+++ b/src/JournalTransactionLine.php
@@ -45,18 +45,18 @@ class JournalTransactionLine extends BaseTransactionLine
     }
 
     /**
-     * @param LineType $type
+     * @param LineType $lineType
      * @return $this
      * @throws Exception
      */
-    public function setType(LineType $type): BaseTransactionLine
+    public function setLineType(LineType $lineType): BaseTransactionLine
     {
         // Only 'detail' and 'vat' are supported.
-        if ($type->equals(LineType::TOTAL())) {
-            throw Exception::invalidLineTypeForTransaction($type, $this);
+        if ($lineType->equals(LineType::TOTAL())) {
+            throw Exception::invalidLineTypeForTransaction($lineType, $this);
         }
 
-        return parent::setType($type);
+        return parent::setLineType($lineType);
     }
 
     /**
@@ -84,7 +84,7 @@ class JournalTransactionLine extends BaseTransactionLine
      */
     public function setDim2(?string $dim2): BaseTransactionLine
     {
-        if ($dim2 !== null && $this->getType()->equals(LineType::VAT())) {
+        if ($dim2 !== null && $this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidDimensionForLineType(2, $this);
         }
 
@@ -120,7 +120,7 @@ class JournalTransactionLine extends BaseTransactionLine
      */
     public function setInvoiceNumber(?string $invoiceNumber): BaseTransactionLine
     {
-        if ($invoiceNumber !== null && !$this->getType()->equals(LineType::DETAIL())) {
+        if ($invoiceNumber !== null && !$this->getLineType()->equals(LineType::DETAIL())) {
             throw Exception::invalidFieldForLineType('invoiceNumber', $this);
         }
 
@@ -139,7 +139,7 @@ class JournalTransactionLine extends BaseTransactionLine
     {
         if (
             $matchStatus !== null &&
-            $this->getType()->equals(LineType::VAT()) &&
+            $this->getLineType()->equals(LineType::VAT()) &&
             $matchStatus != self::MATCHSTATUS_NOTMATCHABLE
         ) {
             throw Exception::invalidMatchStatusForLineType($matchStatus, $this);
@@ -157,7 +157,7 @@ class JournalTransactionLine extends BaseTransactionLine
      */
     public function setMatchLevel(?int $matchLevel): BaseTransactionLine
     {
-        if ($matchLevel !== null && !$this->getType()->equals(LineType::DETAIL())) {
+        if ($matchLevel !== null && !$this->getLineType()->equals(LineType::DETAIL())) {
             throw Exception::invalidFieldForLineType('matchLevel', $this);
         }
 
@@ -173,7 +173,7 @@ class JournalTransactionLine extends BaseTransactionLine
      */
     public function setBaseValueOpen(?Money $baseValueOpen): BaseTransactionLine
     {
-        if ($baseValueOpen !== null && !$this->getType()->equals(LineType::DETAIL())) {
+        if ($baseValueOpen !== null && !$this->getLineType()->equals(LineType::DETAIL())) {
             throw Exception::invalidFieldForLineType('baseValueOpen', $this);
         }
 

--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -104,7 +104,7 @@ class TransactionMapper
                 $transactionLine = new $transactionLineClassName();
 
                 $transactionLine
-                    ->setType(new LineType($lineElement->getAttribute('type')))
+                    ->setLineType(new LineType($lineElement->getAttribute('type')))
                     ->setId($lineElement->getAttribute('id'))
                     ->setDim1(self::getField($transaction, $lineElement, 'dim1'))
                     ->setDim2(self::getField($transaction, $lineElement, 'dim2'))

--- a/src/PurchaseTransactionLine.php
+++ b/src/PurchaseTransactionLine.php
@@ -118,7 +118,7 @@ class PurchaseTransactionLine extends BaseTransactionLine
     {
         if (
             $matchStatus !== null &&
-            in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()]) &&
+            in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()]) &&
             $matchStatus != self::MATCHSTATUS_NOTMATCHABLE
         ) {
             throw Exception::invalidMatchStatusForLineType($matchStatus, $this);
@@ -136,7 +136,7 @@ class PurchaseTransactionLine extends BaseTransactionLine
      */
     public function setMatchLevel(?int $matchLevel): BaseTransactionLine
     {
-        if ($matchLevel !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($matchLevel !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('matchLevel', $this);
         }
 
@@ -152,7 +152,7 @@ class PurchaseTransactionLine extends BaseTransactionLine
      */
     public function setBaseValueOpen(?Money $baseValueOpen): BaseTransactionLine
     {
-        if ($baseValueOpen !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($baseValueOpen !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('baseValueOpen', $this);
         }
 

--- a/src/SalesTransactionLine.php
+++ b/src/SalesTransactionLine.php
@@ -72,7 +72,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setDim2(?string $dim2): BaseTransactionLine
     {
-        if ($dim2 !== null && $this->getType()->equals(LineType::VAT())) {
+        if ($dim2 !== null && $this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidDimensionForLineType(2, $this);
         }
 
@@ -122,7 +122,7 @@ class SalesTransactionLine extends BaseTransactionLine
     {
         if (
             $matchStatus !== null &&
-            in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()]) &&
+            in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()]) &&
             $matchStatus != self::MATCHSTATUS_NOTMATCHABLE
         ) {
             throw Exception::invalidMatchStatusForLineType($matchStatus, $this);
@@ -140,7 +140,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setMatchLevel(?int $matchLevel): BaseTransactionLine
     {
-        if ($matchLevel !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($matchLevel !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('matchLevel', $this);
         }
 
@@ -156,7 +156,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setBaseValueOpen(?Money $baseValueOpen): BaseTransactionLine
     {
-        if ($baseValueOpen !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($baseValueOpen !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('baseValueOpen', $this);
         }
 
@@ -172,7 +172,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setProjectAsset(string $dim3)
     {
-        if (!$this->getType()->equals(LineType::DETAIL())) {
+        if (!$this->getLineType()->equals(LineType::DETAIL())) {
             throw Exception::invalidDimensionForLineType(3, $this);
         }
 
@@ -188,7 +188,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setVatTurnover(?Money $vatTurnover)
     {
-        if (!$this->getType()->equals(LineType::VAT())) {
+        if (!$this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidFieldForLineType("vatturnover", $this);
         }
         return parent::setVatTurnOver($vatTurnover);
@@ -203,7 +203,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setVatBaseTurnover(?Money $vatBaseTurnover)
     {
-        if (!$this->getType()->equals(LineType::VAT())) {
+        if (!$this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidFieldForLineType("vatbaseturnover", $this);
         }
         return parent::setVatBaseTurnover($vatBaseTurnover);
@@ -218,7 +218,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setVatRepTurnover(?Money $vatRepTurnover)
     {
-        if (!$this->getType()->equals(LineType::VAT())) {
+        if (!$this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidFieldForLineType("vatrepturnover", $this);
         }
         return parent::setVatRepTurnover($vatRepTurnover);
@@ -233,7 +233,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setBaseline(?int $baseline)
     {
-        if (!$this->getType()->equals(LineType::VAT())) {
+        if (!$this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidFieldForLineType("baseline", $this);
         }
         return parent::setBaseline($baseline);

--- a/src/Transactions/BankTransactionLine/Base.php
+++ b/src/Transactions/BankTransactionLine/Base.php
@@ -2,19 +2,16 @@
 
 namespace PhpTwinfield\Transactions\BankTransactionLine;
 
-use Money\Money;
 use PhpTwinfield\BankTransaction;
 use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\MatchReference;
 use PhpTwinfield\Office;
 use PhpTwinfield\MatchReferenceInterface;
 use PhpTwinfield\Transactions\TransactionFields\InvoiceNumberField;
-use PhpTwinfield\Transactions\TransactionFields\LinesField;
 use PhpTwinfield\Transactions\TransactionLine;
 use PhpTwinfield\Transactions\TransactionLineFields\CommentField;
 use PhpTwinfield\Transactions\TransactionLineFields\ThreeDimFields;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueFields;
-use PhpTwinfield\Util;
 use Webmozart\Assert\Assert;
 
 abstract class Base implements TransactionLine
@@ -39,7 +36,7 @@ abstract class Base implements TransactionLine
     /**
      * @var LineType
      */
-    private $type;
+    private $lineType;
 
     /**
      * @var string
@@ -86,18 +83,18 @@ abstract class Base implements TransactionLine
     /**
      * @return LineType
      */
-    final public function getType(): LineType
+    final public function getLineType(): LineType
     {
-        return $this->type;
+        return $this->lineType;
     }
 
     /**
-     * @param LineType $type
+     * @param LineType $lineType
      * @return $this
      */
-    final protected function setType(LineType $type)
+    final protected function setLineType(LineType $lineType)
     {
-        $this->type = $type;
+        $this->lineType = $lineType;
         return $this;
     }
 

--- a/src/Transactions/BankTransactionLine/Detail.php
+++ b/src/Transactions/BankTransactionLine/Detail.php
@@ -69,7 +69,7 @@ class Detail extends Base
 
     public function __construct()
     {
-        $this->setType(LineType::DETAIL());
+        $this->setLineType(LineType::DETAIL());
     }
 
     /**

--- a/src/Transactions/BankTransactionLine/Total.php
+++ b/src/Transactions/BankTransactionLine/Total.php
@@ -5,7 +5,6 @@ namespace PhpTwinfield\Transactions\BankTransactionLine;
 use Money\Money;
 use PhpTwinfield\Enums\DebitCredit;
 use PhpTwinfield\Enums\LineType;
-use PhpTwinfield\Transactions\TransactionLineFields\ValueFields;
 
 class Total extends Base
 {
@@ -32,7 +31,7 @@ class Total extends Base
 
     public function __construct()
     {
-        $this->setType(LineType::TOTAL());
+        $this->setLineType(LineType::TOTAL());
     }
 
     public function setBankBalanceAccount(string $dim1)

--- a/src/Transactions/BankTransactionLine/Vat.php
+++ b/src/Transactions/BankTransactionLine/Vat.php
@@ -17,7 +17,7 @@ class Vat extends Base
 
     public function __construct()
     {
-        $this->setType(LineType::VAT());
+        $this->setLineType(LineType::VAT());
     }
 
     /**

--- a/src/Transactions/TransactionFields/LinesField.php
+++ b/src/Transactions/TransactionFields/LinesField.php
@@ -37,8 +37,8 @@ trait LinesField
             $this->lines,
             function (TransactionLine $a, TransactionLine $b) use ($type_order): int
             {
-                $type_index_a = array_search($a->getType(), $type_order, false);
-                $type_index_b = array_search($b->getType(), $type_order, false);
+                $type_index_a = array_search($a->getLineType(), $type_order, false);
+                $type_index_b = array_search($b->getLineType(), $type_order, false);
 
                 if ($type_index_a != $type_index_b) {
                     return $type_index_a <=> $type_index_b;

--- a/src/Transactions/TransactionLine.php
+++ b/src/Transactions/TransactionLine.php
@@ -15,7 +15,7 @@ interface TransactionLine
      *
      * @return LineType
      */
-    public function getType(): LineType;
+    public function getLineType(): LineType;
 
     /**
      * Get the id of the line (or null if not sent to Twinfield yet.

--- a/src/Transactions/TransactionLineFields/PerformanceFields.php
+++ b/src/Transactions/TransactionLineFields/PerformanceFields.php
@@ -34,7 +34,7 @@ trait PerformanceFields
      */
     protected $performanceDate;
 
-    abstract public function getType(): LineType;
+    abstract public function getLineType(): LineType;
 
     /**
      * @return PerformanceType|null
@@ -53,7 +53,7 @@ trait PerformanceFields
     {
         if (
             $performanceType !== null &&
-            !in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()])
+            !in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()])
         ) {
             throw Exception::invalidFieldForLineType('performanceType', $this);
         }
@@ -80,7 +80,7 @@ trait PerformanceFields
     {
         if (
             $performanceCountry !== null &&
-            !in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()])
+            !in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()])
         ) {
             throw Exception::invalidFieldForLineType('performanceCountry', $this);
         }
@@ -107,7 +107,7 @@ trait PerformanceFields
     {
         if (
             $performanceVatNumber !== null &&
-            !in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()])
+            !in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()])
         ) {
             throw Exception::invalidFieldForLineType('performanceVatNumber', $this);
         }
@@ -134,7 +134,7 @@ trait PerformanceFields
     {
         if (
             $performanceDate !== null &&
-            !in_array($this->getType(), [LineType::DETAIL(), LineType::VAT()])
+            !in_array($this->getLineType(), [LineType::DETAIL(), LineType::VAT()])
         ) {
             throw Exception::invalidFieldForLineType('performanceDate', $this);
         }

--- a/src/Transactions/TransactionLineFields/ValueOpenField.php
+++ b/src/Transactions/TransactionLineFields/ValueOpenField.php
@@ -15,7 +15,7 @@ trait ValueOpenField
      */
     protected $valueOpen;
 
-    abstract public function getType(): LineType;
+    abstract public function getLineType(): LineType;
 
     /**
      * @return Money|null
@@ -32,7 +32,7 @@ trait ValueOpenField
      */
     public function setValueOpen(?Money $valueOpen): self
     {
-        if ($valueOpen !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($valueOpen !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('valueOpen', $this);
         }
 

--- a/src/Transactions/TransactionLineFields/VatTotalFields.php
+++ b/src/Transactions/TransactionLineFields/VatTotalFields.php
@@ -24,7 +24,7 @@ trait VatTotalFields
     /**
      * @return LineType
      */
-    abstract public function getType(): LineType;
+    abstract public function getLineType(): LineType;
 
     /**
      * @return Money|null
@@ -41,7 +41,7 @@ trait VatTotalFields
      */
     public function setVatTotal(?Money $vatTotal): self
     {
-        if ($vatTotal !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($vatTotal !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('vatTotal', $this);
         }
 
@@ -65,7 +65,7 @@ trait VatTotalFields
      */
     public function setVatBaseTotal(?Money $vatBaseTotal): self
     {
-        if ($vatBaseTotal !== null && !$this->getType()->equals(LineType::TOTAL())) {
+        if ($vatBaseTotal !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
             throw Exception::invalidFieldForLineType('vatBaseTotal', $this);
         }
 

--- a/tests/IntegrationTests/JournalTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/JournalTransactionIntegrationTest.php
@@ -71,7 +71,7 @@ class JournalTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertCount(2, $journalTransactionLines);
         [$detailLine1, $detailLine2] = $journalTransactionLines;
 
-        $this->assertEquals(LineType::DETAIL(), $detailLine1->getType());
+        $this->assertEquals(LineType::DETAIL(), $detailLine1->getLineType());
         $this->assertSame(1, $detailLine1->getId());
         $this->assertSame('4008', $detailLine1->getDim1());
         $this->assertNull($detailLine1->getDim2());
@@ -93,7 +93,7 @@ class JournalTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($detailLine1->getPerformanceDate());
         $this->assertSame('', $detailLine1->getInvoiceNumber());
 
-        $this->assertEquals(LineType::DETAIL(), $detailLine2->getType());
+        $this->assertEquals(LineType::DETAIL(), $detailLine2->getLineType());
         $this->assertSame(2, $detailLine2->getId());
         $this->assertSame('1300', $detailLine2->getDim1());
         $this->assertSame('1000', $detailLine2->getDim2());
@@ -128,14 +128,14 @@ class JournalTransactionIntegrationTest extends BaseIntegrationTest
 
         $detailLine1 = new JournalTransactionLine();
         $detailLine1
-            ->setType(LineType::DETAIL())
+            ->setLineType(LineType::DETAIL())
             ->setId('1')
             ->setDim1('4008')
             ->setValue(Money::EUR(-43555));
 
         $detailLine2 = new JournalTransactionLine();
         $detailLine2
-            ->setType(LineType::DETAIL())
+            ->setLineType(LineType::DETAIL())
             ->setId('2')
             ->setDim1('1300')
             ->setDim2('1000')

--- a/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
@@ -71,7 +71,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertCount(3, $purchaseTransactionLines);
         [$totalLine, $detailLine, $vatLine] = $purchaseTransactionLines;
 
-        $this->assertEquals(LineType::TOTAL(), $totalLine->getType());
+        $this->assertEquals(LineType::TOTAL(), $totalLine->getLineType());
         $this->assertSame(1, $totalLine->getId());
         $this->assertSame('1600', $totalLine->getDim1());
         $this->assertSame('2000', $totalLine->getDim2());
@@ -91,7 +91,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertEquals(Money::EUR(2100), $totalLine->getVatBaseTotal());
         $this->assertEquals(Money::EUR(12100), $totalLine->getValueOpen());
 
-        $this->assertEquals(LineType::DETAIL(), $detailLine->getType());
+        $this->assertEquals(LineType::DETAIL(), $detailLine->getLineType());
         $this->assertSame(2, $detailLine->getId());
         $this->assertSame('8020', $detailLine->getDim1());
         $this->assertNull($detailLine->getDim2());
@@ -111,7 +111,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($detailLine->getVatBaseTotal());
         $this->assertNull($detailLine->getValueOpen());
 
-        $this->assertEquals(LineType::VAT(), $vatLine->getType());
+        $this->assertEquals(LineType::VAT(), $vatLine->getLineType());
         $this->assertSame(3, $vatLine->getId());
         $this->assertSame('1510', $vatLine->getDim1());
         $this->assertNull($vatLine->getDim2());
@@ -149,7 +149,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
 
         $totalLine = new PurchaseTransactionLine();
         $totalLine
-            ->setType(LineType::TOTAL())
+            ->setLineType(LineType::TOTAL())
             ->setId('1')
             ->setDim1('1600')
             ->setDim2('2000')
@@ -158,7 +158,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
 
         $detailLine = new PurchaseTransactionLine();
         $detailLine
-            ->setType(LineType::DETAIL())
+            ->setLineType(LineType::DETAIL())
             ->setId('2')
             ->setDim1('8020')
             ->setValue(Money::EUR(-10000))

--- a/tests/IntegrationTests/SalesTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/SalesTransactionIntegrationTest.php
@@ -73,7 +73,7 @@ class SalesTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertCount(3, $salesTransactionLines);
         [$totalLine, $detailLine, $vatLine] = $salesTransactionLines;
 
-        $this->assertEquals(LineType::TOTAL(), $totalLine->getType());
+        $this->assertEquals(LineType::TOTAL(), $totalLine->getLineType());
         $this->assertSame(1, $totalLine->getId());
         $this->assertSame('1300', $totalLine->getDim1());
         $this->assertSame('1000', $totalLine->getDim2());
@@ -97,7 +97,7 @@ class SalesTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($totalLine->getPerformanceVatNumber());
         $this->assertNull($totalLine->getPerformanceDate());
 
-        $this->assertEquals(LineType::DETAIL(), $detailLine->getType());
+        $this->assertEquals(LineType::DETAIL(), $detailLine->getLineType());
         $this->assertSame(2, $detailLine->getId());
         $this->assertSame('8020', $detailLine->getDim1());
         $this->assertNull($detailLine->getDim2());
@@ -121,7 +121,7 @@ class SalesTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($detailLine->getPerformanceVatNumber());
         $this->assertNull($detailLine->getPerformanceDate());
 
-        $this->assertEquals(LineType::VAT(), $vatLine->getType());
+        $this->assertEquals(LineType::VAT(), $vatLine->getLineType());
         $this->assertSame(3, $vatLine->getId());
         $this->assertSame('1530', $vatLine->getDim1());
         $this->assertNull($vatLine->getDim2());
@@ -163,7 +163,7 @@ class SalesTransactionIntegrationTest extends BaseIntegrationTest
 
         $totalLine = new SalesTransactionLine();
         $totalLine
-            ->setType(LineType::TOTAL())
+            ->setLineType(LineType::TOTAL())
             ->setId('1')
             ->setDim1('1300')
             ->setDim2('1000')
@@ -172,7 +172,7 @@ class SalesTransactionIntegrationTest extends BaseIntegrationTest
 
         $detailLine = new SalesTransactionLine();
         $detailLine
-            ->setType(LineType::DETAIL())
+            ->setLineType(LineType::DETAIL())
             ->setId('2')
             ->setDim1('8020')
             ->setValue(Money::EUR(10000))

--- a/tests/UnitTests/PurchaseTransactionsUnitTest.php
+++ b/tests/UnitTests/PurchaseTransactionsUnitTest.php
@@ -18,15 +18,15 @@ class PurchaseTransactionsUnitTest extends TestCase
         $purchase = new PurchaseTransaction();
 
         $detail = new PurchaseTransactionLine();
-        $detail->setType(LineType::DETAIL());
+        $detail->setLineType(LineType::DETAIL());
         $detail->setId(3);
 
         $vat = new PurchaseTransactionLine();
-        $vat->setType(LineType::VAT());
+        $vat->setLineType(LineType::VAT());
         $vat->setId(4);
 
         $total = new PurchaseTransactionLine();
-        $total->setType(LineType::TOTAL());
+        $total->setLineType(LineType::TOTAL());
         $total->setId(5);
 
 

--- a/tests/UnitTests/SalesTransactionLineUnitTest.php
+++ b/tests/UnitTests/SalesTransactionLineUnitTest.php
@@ -22,7 +22,7 @@ class SalesTransactionLineUnitTest extends \PHPUnit\Framework\TestCase
 
     public function testSetVatTurnover()
     {
-        $this->line->setType(LineType::VAT());
+        $this->line->setLineType(LineType::VAT());
 
         $this->assertSame($this->line, $this->line->setVatTurnover(Money::EUR(1)), "Fluid interface is expected");
         $this->assertEquals(Money::EUR(1), $this->line->getVatTurnover());
@@ -30,7 +30,7 @@ class SalesTransactionLineUnitTest extends \PHPUnit\Framework\TestCase
 
     public function testSetVatBaseTurnover()
     {
-        $this->line->setType(LineType::VAT());
+        $this->line->setLineType(LineType::VAT());
 
         $this->assertSame($this->line, $this->line->setVatBaseTurnover(Money::EUR(1)), "Fluid interface is expected");
         $this->assertEquals(Money::EUR(1), $this->line->getVatBaseTurnover());
@@ -38,7 +38,7 @@ class SalesTransactionLineUnitTest extends \PHPUnit\Framework\TestCase
 
     public function testSetVatRepTurnover()
     {
-        $this->line->setType(LineType::VAT());
+        $this->line->setLineType(LineType::VAT());
 
         $this->assertSame($this->line, $this->line->setVatRepTurnover(Money::EUR(1)), "Fluid interface is expected");
         $this->assertEquals(Money::EUR(1), $this->line->getVatRepTurnover());

--- a/tests/UnitTests/Transactions/TransactionLineFields/ValueFieldsUnitTest.php
+++ b/tests/UnitTests/Transactions/TransactionLineFields/ValueFieldsUnitTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Money\Money;
+use PhpTwinfield\Enums\DebitCredit;
+use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\Transactions\TransactionLineFields\ValueFields;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PhpTwinfield\Transactions\TransactionLineFields\ValueFields
+ */
+class ValueFieldsUnitTest extends TestCase
+{
+    /**
+     * @param LineType|null $lineType
+     * @param Money         $value
+     * @param DebitCredit   $expectedDebitCredit
+     *
+     * @dataProvider dpTestSetValueAlsoSetsDebitCredit
+     */
+    public function testSetValueAlsoSetsDebitCredit(?LineType $lineType, Money $value, DebitCredit $expectedDebitCredit)
+    {
+        /** @var ValueFields|PHPUnit_Framework_MockObject_MockObject $valueFieldsTrait */
+        $valueFieldsTrait = $this->getMockForTrait(ValueFields::class);
+        $valueFieldsTrait
+            ->expects($this->any())
+            ->method('getLineType')
+            ->willReturn($lineType);
+
+        $valueFieldsTrait->setValue($value);
+
+        $this->assertEquals($expectedDebitCredit, $valueFieldsTrait->getDebitCredit());
+    }
+
+    public function dpTestSetValueAlsoSetsDebitCredit(): array
+    {
+        return [
+            /*
+             * If line type = total
+             * - In case of a 'normal' transaction `debit`.
+             * - In case of a credit transaction `credit`.
+             */
+            'positive total'             => [LineType::TOTAL(),  Money::EUR( 1), DebitCredit::DEBIT()],
+            'negative total'             => [LineType::TOTAL(),  Money::EUR(-1), DebitCredit::CREDIT()],
+            /*
+             * If line type = detail or vat
+             * - In case of a 'normal' transaction `credit`.
+             * - In case of a credit transaction `debit`.
+             */
+            'positive detail'            => [LineType::DETAIL(), Money::EUR( 1), DebitCredit::CREDIT()],
+            'positive vat'               => [LineType::VAT(),    Money::EUR( 1), DebitCredit::CREDIT()],
+            'positive without line type' => [null,               Money::EUR( 1), DebitCredit::CREDIT()],
+            'negative detail'            => [LineType::DETAIL(), Money::EUR(-1), DebitCredit::DEBIT()],
+            'negative vat'               => [LineType::VAT(),    Money::EUR(-1), DebitCredit::DEBIT()],
+            'negative without line type' => [null,               Money::EUR(-1), DebitCredit::DEBIT()],
+        ];
+    }
+
+    /**
+     * @param LineType|null $lineType
+     * @param DebitCredit   $newDebitCredit
+     * @param bool          $expectedIsPositive
+     *
+     * @dataProvider dpTestSetDebitCreditUpdatesValueSign
+     */
+    public function testSetDebitCreditUpdatesValueSign(?LineType $lineType, DebitCredit $newDebitCredit, bool $expectedIsPositive)
+    {
+        /** @var ValueFields|PHPUnit_Framework_MockObject_MockObject $valueFieldsTrait */
+        $valueFieldsTrait = $this->getMockForTrait(ValueFields::class);
+        $valueFieldsTrait
+            ->expects($this->any())
+            ->method('getLineType')
+            ->willReturn($lineType);
+
+        $valueFieldsTrait->setValue(Money::EUR(1));
+        $valueFieldsTrait->setDebitCredit($newDebitCredit);
+
+        if ($expectedIsPositive) {
+            $this->assertTrue($valueFieldsTrait->getSignedValue()->isPositive());
+        } else {
+            $this->assertTrue($valueFieldsTrait->getSignedValue()->isNegative());
+        }
+    }
+
+    public function dpTestSetDebitCreditUpdatesValueSign(): array
+    {
+        return [
+            /*
+             * If line type = total
+             * - In case of a 'normal' transaction `debit`.
+             * - In case of a credit transaction `credit`.
+             */
+            'debit total'              => [LineType::TOTAL(),  DebitCredit::DEBIT(),  true],
+            'credit total'             => [LineType::TOTAL(),  DebitCredit::CREDIT(), false],
+            /*
+             * If line type = detail or vat
+             * - In case of a 'normal' transaction `credit`.
+             * - In case of a credit transaction `debit`.
+             */
+            'debit detail'             => [LineType::DETAIL(), DebitCredit::DEBIT(),  false],
+            'credit detail'            => [LineType::DETAIL(), DebitCredit::CREDIT(), true],
+            'debit vat'                => [LineType::VAT(),    DebitCredit::DEBIT(),  false],
+            'credit vat'               => [LineType::VAT(),    DebitCredit::CREDIT(), true],
+            'debit without line type'  => [null,               DebitCredit::DEBIT(),  false],
+            'credit without line type' => [null,               DebitCredit::CREDIT(), true],
+        ];
+    }
+
+    public function testDebitCreditCanOnlyBeSetAfterValueIsSet()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        /** @var ValueFields|PHPUnit_Framework_MockObject_MockObject $valueFieldsTrait */
+        $valueFieldsTrait = $this->getMockForTrait(ValueFields::class);
+        $valueFieldsTrait
+            ->expects($this->any())
+            ->method('getLineType')
+            ->willReturn(null);
+
+        $valueFieldsTrait->setDebitCredit(DebitCredit::DEBIT());
+    }
+}


### PR DESCRIPTION
I had to rename `getType()` on transaction lines to `getLineType()` because there already existed a `getType()` method on electronic bank statement transactions with another meaning.

This is done in a separate commit, the real change is done in 1cb690a.