### PR TITLE
Fix customers send all

### DIFF
--- a/src/DomDocuments/BaseDocument.php
+++ b/src/DomDocuments/BaseDocument.php
@@ -52,10 +52,11 @@ abstract class BaseDocument extends \DOMDocument
         );
     }
 
-    protected function  appendOfficeField(\DOMElement $element, Office $office): void
+    protected function appendOfficeField(\DOMElement $element, Office $office): void
     {
-        $office = $this->createNodeWithTextContent("office", $office->getCode());
-        $element->appendChild($office);
+        $element->appendChild(
+            $this->createNodeWithTextContent("office", $office->getCode())
+        );
     }
 
     /**

--- a/src/DomDocuments/CustomersDocument.php
+++ b/src/DomDocuments/CustomersDocument.php
@@ -14,27 +14,16 @@ use PhpTwinfield\CustomerBank;
  * @author Leon Rowland <leon@rowland.nl>
  * @copyright (c) 2013, Pronamic
  */
-class CustomersDocument extends \DOMDocument
+class CustomersDocument extends BaseDocument
 {
     /**
-     * Holds the <dimension> element
-     * that all additional elements should be a child of
-     * @var \DOMElement
-     */
-    private $dimensionElement;
-
-    /**
-     * Creates the <dimension> element and adds it to the property
-     * dimensionElement
+     * Multiple customers can be created at once by enclosing them by the dimensions element.
      *
-     * @access public
+     * @return string
      */
-    public function __construct()
+    protected function getRootTagName(): string
     {
-        parent::__construct('1.0', 'UTF-8');
-
-        $this->dimensionElement = $this->createElement('dimension');
-        $this->appendChild($this->dimensionElement);
+        return 'dimensions';
     }
 
     /**
@@ -45,6 +34,8 @@ class CustomersDocument extends \DOMDocument
      */
     public function addCustomer(Customer $customer): void
     {
+        $customerEl = $this->createElement("dimension");
+
         // Elements and their associated methods for customer
         $customerTags = array(
             'code'      => 'getCode',
@@ -58,24 +49,23 @@ class CustomersDocument extends \DOMDocument
             $customerTags['office'] = 'getOffice';
         }
 
-        $status = $customer->getStatus();
-        if (!empty($status)) {
-            $this->dimensionElement->setAttribute('status', $status);
+        if (!empty($customer->getStatus())) {
+            $customerTags['status'] = 'getStatus';
         }
 
         // Go through each customer element and use the assigned method
         foreach ($customerTags as $tag => $method) {
 
-            // Make text node for method value
-            if($customer->$method()) {
-                $node = $this->createTextNode($customer->$method());
+            if($value = $customer->$method()) {
+                // Make text node for method value
+                $node = $this->createTextNode($value);
 
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
                 $element->appendChild($node);
 
                 // Add the full element
-                $this->dimensionElement->appendChild($element);
+                $customerEl->appendChild($element);
             }
         }
 
@@ -94,7 +84,7 @@ class CustomersDocument extends \DOMDocument
 
             // Make the financial element
             $financialElement = $this->createElement('financials');
-            $this->dimensionElement->appendChild($financialElement);
+            $customerEl->appendChild($financialElement);
 
             // Go through each financial element and use the assigned method
             foreach ($financialsTags as $tag => $method) {
@@ -132,7 +122,7 @@ class CustomersDocument extends \DOMDocument
 
             // Make the creditmanagement element
             $creditManagementElement = $this->createElement('creditmanagement');
-            $this->dimensionElement->appendChild($creditManagementElement);
+            $customerEl->appendChild($creditManagementElement);
 
             // Go through each credit management element and use the assigned method
             foreach ($creditManagementTags as $tag => $method) {
@@ -176,7 +166,7 @@ class CustomersDocument extends \DOMDocument
 
             // Make addresses element
             $addressesElement = $this->createElement('addresses');
-            $this->dimensionElement->appendChild($addressesElement);
+            $customerEl->appendChild($addressesElement);
 
             // Go through each address assigned to the customer
             foreach ($addresses as $address) {
@@ -224,7 +214,7 @@ class CustomersDocument extends \DOMDocument
 
             // Make banks element
             $banksElement = $this->createElement('banks');
-            $this->dimensionElement->appendChild($banksElement);
+            $customerEl->appendChild($banksElement);
 
             // Go through each bank assigned to the customer
             /** @var CustomerBank $bank */
@@ -270,5 +260,7 @@ class CustomersDocument extends \DOMDocument
                 $bankElement->appendChild($addressElement);
             }
         }
+
+        $this->rootElement->appendChild($customerEl);
     }
 }

--- a/tests/IntegrationTests/resources/customerSendRequest.xml
+++ b/tests/IntegrationTests/resources/customerSendRequest.xml
@@ -1,49 +1,51 @@
-<dimension>    
-    <name>Customer 0</name>
-    <type>DEB</type>
-    <office>001</office>
-    <financials>
-        <duedays>30</duedays>
-        <payavailable>true</payavailable>
-        <paycode>SEPANLDD</paycode>
-        <vatcode/>
-        <ebilling>false</ebilling>
-        <ebillmail/>
-    </financials>
-    <addresses>
-        <address type="invoice" default="true">
-            <name>Customer 0</name>
-            <contact/>
-            <country>NL</country>
-            <city>Place</city>
-            <postcode>1000</postcode>
-            <telephone>010-123452000</telephone>
-            <telefax>010-12342000</telefax>
-            <email>info@example.com</email>
-            <field1>Customer 1</field1>
-            <field2>Streetname part 1 - 1</field2>
-            <field3>Streetname part 1 - 2</field3>
-            <field4></field4>
-            <field5></field5>
-            <field6></field6>
-        </address>
-    </addresses>
-    <banks>
-        <bank default="true">
-            <ascription>Customer 1</ascription>
-            <accountnumber>123456789</accountnumber>
-            <bankname>ABN Amro</bankname>
-            <biccode>ABNANL2A</biccode>
-            <city>Place</city>
-            <country>NL</country>
-            <iban>NL02ABNA0123456789</iban>
-            <natbiccode></natbiccode>
-            <postcode></postcode>
-            <state></state>
-            <address>
-                <field2></field2>
-                <field3></field3>
-            </address>
-        </bank>
-    </banks>
-</dimension>
+<dimensions>
+	<dimension>
+		<name>Customer 0</name>
+		<type>DEB</type>
+		<office>001</office>
+		<financials>
+			<duedays>30</duedays>
+			<payavailable>true</payavailable>
+			<paycode>SEPANLDD</paycode>
+			<vatcode/>
+			<ebilling>false</ebilling>
+			<ebillmail/>
+		</financials>
+		<addresses>
+			<address type="invoice" default="true">
+				<name>Customer 0</name>
+				<contact/>
+				<country>NL</country>
+				<city>Place</city>
+				<postcode>1000</postcode>
+				<telephone>010-123452000</telephone>
+				<telefax>010-12342000</telefax>
+				<email>info@example.com</email>
+				<field1>Customer 1</field1>
+				<field2>Streetname part 1 - 1</field2>
+				<field3>Streetname part 1 - 2</field3>
+				<field4></field4>
+				<field5></field5>
+				<field6></field6>
+			</address>
+		</addresses>
+		<banks>
+			<bank default="true">
+				<ascription>Customer 1</ascription>
+				<accountnumber>123456789</accountnumber>
+				<bankname>ABN Amro</bankname>
+				<biccode>ABNANL2A</biccode>
+				<city>Place</city>
+				<country>NL</country>
+				<iban>NL02ABNA0123456789</iban>
+				<natbiccode></natbiccode>
+				<postcode></postcode>
+				<state></state>
+				<address>
+					<field2></field2>
+					<field3></field3>
+				</address>
+			</bank>
+		</banks>
+	</dimension>
+</dimensions>

--- a/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace PhpTwinfield\UnitTests;
+
+use PhpTwinfield\Customer;
+use PhpTwinfield\CustomerAddress;
+use PhpTwinfield\CustomerBank;
+use PhpTwinfield\CustomerCreditManagement;
+use PhpTwinfield\DomDocuments\CustomersDocument;
+use PhpTwinfield\Office;
+use PHPUnit\Framework\TestCase;
+
+class CustomersDocumentUnitTest extends TestCase
+{
+    /**
+     * @var CustomersDocument
+     */
+    protected $document;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->document = new CustomersDocument();
+    }
+
+    public function testXmlIsCreatedPerSpec()
+    {
+        $customer = new Customer();
+        $customer->setCode('D123456');
+        $customer->setName('Chuck Norris');
+        $customer->setWebsite('http://example.org');
+        $customer->setOffice(Office::fromCode("DEV-10000"));
+
+        $customer->setDueDays(1);
+        $customer->setPayAvailable(true);
+        $customer->setPayCode('pay-code');
+        $customer->setVatCode('vat-code');
+        $customer->setEBilling(true);
+        $customer->setEBillMail('ebillingmail@mail.com');
+
+        $customer->setCreditManagement(
+            (new CustomerCreditManagement())
+                ->setResponsibleUser('responsible-user')
+                ->setBaseCreditLimit(50)
+                ->setSendReminder(true)
+                ->setReminderEmail('reminderemail@mail.com')
+                ->setBlocked(false)
+                ->setFreeText1('free1')
+                ->setFreeText2('free2')
+                ->setComment('comment    comment')
+        );
+        $customer->addAddress(
+            (new CustomerAddress())
+                ->setDefault(true)
+                ->setType('invoice')
+                ->setName('My Address')
+                ->setContact('My Contact')
+                ->setCountry('nl')
+                ->setCity('city')
+                ->setPostcode('postal code')
+                ->setTelephone('phone number')
+                ->setFax('fax number')
+                ->setEmail('email@mail.com')
+                ->setField1('field 1')
+                ->setField2('field 2')
+                ->setField3('field 3')
+                ->setField4('field 4')
+                ->setField5('field 5')
+                ->setField6('field 6')
+        );
+        $customer->addBank(
+            (new CustomerBank())
+                ->setDefault(true)
+                ->setAscription('ascriptor')
+                ->setAccountnumber('account number')
+                ->setBankname('bank name')
+                ->setBiccode('bic code')
+                ->setCity('city')
+                ->setCountry('nl')
+                ->setIban('iban')
+                ->setNatbiccode('nat-bic')
+                ->setPostcode('postcode')
+                ->setState('state')
+                ->setAddressField2('address 2')
+                ->setAddressField3('address 3')
+        );
+
+        $this->document->addCustomer($customer);
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<XML
+<?xml version="1.0"?>
+<dimensions>
+	<dimension>
+	    <code>D123456</code>
+	    <name>Chuck Norris</name>
+	    <type>DEB</type>
+	    <website>http://example.org</website>
+	    <office>DEV-10000</office>
+	    <financials>
+	        <duedays>1</duedays>
+	        <payavailable>true</payavailable>
+	        <paycode>pay-code</paycode>
+	        <vatcode>vat-code</vatcode>
+	        <ebilling>true</ebilling>
+	        <ebillmail>ebillingmail@mail.com</ebillmail>
+        </financials>
+        <creditmanagement>
+            <responsibleuser>responsible-user</responsibleuser>
+            <basecreditlimit>50</basecreditlimit>
+            <sendreminder>true</sendreminder>
+            <reminderemail>reminderemail@mail.com</reminderemail>
+            <blocked>false</blocked>
+            <freetext1>free1</freetext1>
+            <freetext2>free2</freetext2>
+            <comment>comment    comment</comment>
+        </creditmanagement>
+        <addresses>
+            <address default="1" type="invoice">
+                <name>My Address</name>
+                <contact>My Contact</contact>
+                <country>nl</country>
+                <city>city</city>
+                <postcode>postal code</postcode>
+                <telephone>phone number</telephone>
+                <telefax>fax number</telefax>
+                <email>email@mail.com</email>
+                <field1>field 1</field1>
+                <field2>field 2</field2>
+                <field3>field 3</field3>
+                <field4>field 4</field4>
+                <field5>field 5</field5>
+                <field6>field 6</field6>
+            </address>
+        </addresses>
+        <banks>
+            <bank default="1">
+                <ascription>ascriptor</ascription>
+                <accountnumber>account number</accountnumber>
+                <bankname>bank name</bankname>
+                <biccode>bic code</biccode>
+                <city>city</city>
+                <country>nl</country>
+                <iban>iban</iban>
+                <natbiccode>nat-bic</natbiccode>
+                <postcode>postcode</postcode>
+                <state>state</state>
+                <address>
+                    <field2>address 2</field2>                
+                    <field3>address 3</field3>                
+                </address>
+            </bank>
+        </banks>
+	</dimension>
+</dimensions>
+XML
+            ,
+            $this->document->saveXML()
+        );
+    }
+}

--- a/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
@@ -88,6 +88,14 @@ class CustomersDocumentUnitTest extends TestCase
 
         $this->document->addCustomer($customer);
 
+        $customer = new Customer();
+        $customer->setCode('D654321');
+        $customer->setName('Nuck CHorris');
+        $customer->setWebsite('http://example.org');
+        $customer->setOffice(Office::fromCode("DEV-00001"));
+
+        $this->document->addCustomer($customer);
+
         $this->assertXmlStringEqualsXmlString(
             <<<XML
 <?xml version="1.0"?>
@@ -152,7 +160,14 @@ class CustomersDocumentUnitTest extends TestCase
                 </address>
             </bank>
         </banks>
-	</dimension>
+    </dimension>
+    <dimension>
+        <code>D654321</code>
+        <name>Nuck Chorris</name>
+        <type>DEB</type>
+        <website>http://example.org</website>
+        <office>DEV-00001</office>
+    </dimension>
 </dimensions>
 XML
             ,


### PR DESCRIPTION
The `CustomerApiConnector::sendAll()` was broken because `CustomersDocument` has an implementation that only supported once customer.

This resulted in always having 1 `<dimension>` element with duplicate info for all customers (e.g. calling `$document->addCustomer($customer)` 20 times would result in 20 `<code>` elements, etc.