### PR TITLE
Added support for parsing the lines in BankTransactions.

### DIFF
--- a/src/Mappers/BankTransactionMapper.php
+++ b/src/Mappers/BankTransactionMapper.php
@@ -1,33 +1,199 @@
 <?php
 namespace PhpTwinfield\Mappers;
 
+use PhpTwinfield\Enums\PerformanceType;
+use PhpTwinfield\Office;
+use PhpTwinfield\Transactions\BankTransactionLine\Base;
+use PhpTwinfield\Transactions\BankTransactionLine\Detail;
+use PhpTwinfield\Transactions\BankTransactionLine\Total;
+use PhpTwinfield\Transactions\BankTransactionLine\Vat;
 use PhpTwinfield\BankTransaction;
+use PhpTwinfield\Enums\DebitCredit;
+use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\Util;
 
 class BankTransactionMapper extends BaseMapper
 {
     public static function map(\DOMDocument $document): BankTransaction
     {
-        $banktransaction = new BankTransaction();
+        $bankTransaction = new BankTransaction();
 
         $element = $document->documentElement;
 
         if (!empty($element->getAttribute("autobalancevat"))) {
-            $banktransaction->setAutoBalanceVat(Util::parseBoolean($element->getAttribute("autobalancevat")));
+            $bankTransaction->setAutoBalanceVat(Util::parseBoolean($element->getAttribute("autobalancevat")));
         }
 
         if (!empty($element->getAttribute("raisewarning"))) {
-            $banktransaction->setRaiseWarning(Util::parseBoolean($element->getAttribute("raisewarning")));
+            $bankTransaction->setRaiseWarning(Util::parseBoolean($element->getAttribute("raisewarning")));
         }
 
-        self::setFromTagValue($document, "code", [$banktransaction, "setCode"]);
-        self::setFromTagValue($document, "office", [$banktransaction, "setOffice"]);
-        self::setFromTagValue($document, "period", [$banktransaction, "setPeriod"]);
-        self::setFromTagValue($document, "startvalue", [$banktransaction, "setStartValue"]);
+        self::setFromTagValue($document, "code", [$bankTransaction, "setCode"]);
+        self::setFromTagValue($document, "office", [$bankTransaction, "setOffice"]);
+        self::setFromTagValue($document, "period", [$bankTransaction, "setPeriod"]);
+        self::setFromTagValue($document, "startvalue", [$bankTransaction, "setStartValue"]);
 
-        self::setFromTagValue($document, "statementnumber", [$banktransaction, "setStatementNumber"]);
-        self::setFromTagValue($document, "number", [$banktransaction, "setNumber"]);
+        self::setFromTagValue($document, "statementnumber", [$bankTransaction, "setStatementNumber"]);
+        self::setFromTagValue($document, "number", [$bankTransaction, "setNumber"]);
 
-        return $banktransaction;
+        /**  @var \DOMElement $lineElement */
+        foreach ($element->getElementsByTagName("line") as $lineElement) {
+            switch ($lineElement->getAttribute("type")) {
+                case LineType::TOTAL():
+                    $bankTransaction->addLine(self::createTotalBankTransactionLine($bankTransaction, $lineElement));
+                    break;
+                case LineType::DETAIL():
+                    $bankTransaction->addLine(self::createDetailBankTransactionLine($bankTransaction, $lineElement));
+                    break;
+                case LineType::VAT():
+                    $bankTransaction->addLine(self::createVatBankTransactionLine($bankTransaction, $lineElement));
+                    break;
+            }
+        }
+
+        return $bankTransaction;
+    }
+
+    private static function createTotalBankTransactionLine(BankTransaction $bankTransaction, \DOMElement $lineElement): Total
+    {
+        $line = new Total();
+        self::setBankTransactionLineBaseFields($bankTransaction, $lineElement, $line);
+
+        $line->setBankBalanceAccount(self::getField($lineElement, "dim1"));
+
+        $vatTotal = self::getField($lineElement, "vattotal");
+        if ($vatTotal) {
+            $line->setVatTotal(Util::parseMoney($vatTotal, $bankTransaction->getCurrency()));
+        }
+        $vatBaseTotal = self::getField($lineElement, "vatbasetotal");
+        if ($vatBaseTotal) {
+            $line->setVatBaseTotal(Util::parseMoney($vatBaseTotal, $bankTransaction->getCurrency()));
+        }
+        $vatRepTotal = self::getField($lineElement, "vatreptotal");
+        if ($vatRepTotal) {
+            $line->setVatRepTotal(Util::parseMoney($vatRepTotal, $bankTransaction->getCurrency()));
+        }
+
+        return $line;
+    }
+
+    private static function createDetailBankTransactionLine(BankTransaction $bankTransaction, \DOMElement $lineElement): Detail
+    {
+        $line = new Detail();
+        self::setBankTransactionLineBaseFields($bankTransaction, $lineElement, $line);
+        self::setBankTransactionLinePerformanceFields($lineElement, $line);
+
+        $line->setAccount(self::getField($lineElement, "dim1"));
+
+        $customerOrSupplierOrCostCenter = self::getField($lineElement, "dim2");
+        if ($customerOrSupplierOrCostCenter) {
+            $line->setCustomerOrSupplierOrCostCenter($customerOrSupplierOrCostCenter);
+        }
+        $vatCode = self::getField($lineElement, "vatcode");
+        if ($vatCode) {
+            $line->setVatCode($vatCode);
+        }
+        $vatValue = self::getField($lineElement, "vatvalue");
+        if ($vatValue) {
+            $line->setVatValue(Util::parseMoney($vatValue, $bankTransaction->getCurrency()));
+        }
+        $vatBaseValue = self::getField($lineElement, "vatbasevalue");
+        if ($vatBaseValue) {
+            $line->setVatBaseValue(Util::parseMoney($vatBaseValue, $bankTransaction->getCurrency()));
+        }
+        $vatRepValue = self::getField($lineElement, "vatrepvalue");
+        if ($vatRepValue) {
+            $line->setVatRepValue(Util::parseMoney($vatRepValue, $bankTransaction->getCurrency()));
+        }
+        $projectOrAsset = self::getField($lineElement, "dim3");
+        if ($projectOrAsset) {
+            $line->setProjectOrAsset($projectOrAsset);
+        }
+
+        return $line;
+    }
+
+    private static function createVatBankTransactionLine(BankTransaction $bankTransaction, \DOMElement $lineElement): Vat
+    {
+        $line = new Vat();
+        self::setBankTransactionLineBaseFields($bankTransaction, $lineElement, $line);
+        self::setBankTransactionLinePerformanceFields($lineElement, $line);
+
+        $vatTurnover = self::getField($lineElement, "vatturnover");
+        $line->setVatTurnover(Util::parseMoney($vatTurnover, $bankTransaction->getCurrency()));
+        $vatBaseTurnover = self::getField($lineElement, "vatbaseturnover");
+        $line->setVatBaseTurnover(Util::parseMoney($vatBaseTurnover, $bankTransaction->getCurrency()));
+        $vatRepTurnover = self::getField($lineElement, "vatrepturnover");
+        $line->setVatRepTurnover(Util::parseMoney($vatRepTurnover, $bankTransaction->getCurrency()));
+
+        $vatCode = self::getField($lineElement, "vatcode");
+        if ($vatCode) {
+            $line->setVatCode($vatCode);
+        }
+        $vatBalanceAccount = self::getField($lineElement, "dim1");
+        if ($vatBalanceAccount) {
+            $line->setVatBalanceAccount($vatBalanceAccount);
+        }
+
+        return $line;
+    }
+
+    private static function setBankTransactionLineBaseFields(
+        BankTransaction $bankTransaction,
+        \DOMElement $lineElement,
+        Base $line
+    ): void {
+        $line->setId($lineElement->getAttribute("id"));
+        $line->setDescription(self::getField($lineElement, "description"));
+        $value = self::getField($lineElement, 'value');
+        $line->setValue(Util::parseMoney($value, $bankTransaction->getCurrency()));
+        $line->setInvoiceNumber(self::getField($lineElement, "invoicenumber"));
+
+        $debitCredit = self::getField($lineElement, 'debitcredit');
+        if ($debitCredit) {
+            $line->setDebitCredit(new DebitCredit($debitCredit));
+        }
+        $destOffice = self::getField($lineElement, "destoffice");
+        if ($destOffice) {
+            $line->setDestOffice(Office::fromCode($destOffice));
+        }
+        $freeChar = self::getField($lineElement, "freechar");
+        if ($freeChar) {
+            $line->setFreeChar($freeChar);
+        }
+        $comment = self::getField($lineElement, "comment");
+        if ($comment) {
+            $line->setComment($comment);
+        }
+    }
+
+    private static function setBankTransactionLinePerformanceFields(\DOMElement $lineElement, Base $line): void
+    {
+        $performanceType = self::getField($lineElement, "performancetype");
+        if ($performanceType) {
+            $line->setPerformanceType(new PerformanceType($performanceType));
+        }
+        $performanceCountry = self::getField($lineElement, "performancecountry");
+        if ($performanceCountry) {
+            $line->setPerformanceCountry($performanceCountry);
+        }
+        $performanceVatNumber = self::getField($lineElement, "performancevatnumber");
+        if ($performanceVatNumber) {
+            $line->setPerformanceVatNumber($performanceVatNumber);
+        }
+        $performanceDate = self::getField($lineElement, "performancedate");
+        if ($performanceDate) {
+            $line->setPerformanceDate($performanceDate);
+        }
+    }
+
+    private static function getField(\DOMElement $element, string $fieldTagName): ?string
+    {
+        $fieldElement = $element->getElementsByTagName($fieldTagName)->item(0);
+        if (!isset($fieldElement)) {
+            return null;
+        }
+
+        return $fieldElement->textContent;
     }
 }

--- a/src/Mappers/BankTransactionMapper.php
+++ b/src/Mappers/BankTransactionMapper.php
@@ -123,9 +123,11 @@ class BankTransactionMapper extends BaseMapper
         $line->setVatTurnover(Util::parseMoney($vatTurnover, $bankTransaction->getCurrency()));
         $vatBaseTurnover = self::getField($lineElement, "vatbaseturnover");
         $line->setVatBaseTurnover(Util::parseMoney($vatBaseTurnover, $bankTransaction->getCurrency()));
-        $vatRepTurnover = self::getField($lineElement, "vatrepturnover");
-        $line->setVatRepTurnover(Util::parseMoney($vatRepTurnover, $bankTransaction->getCurrency()));
 
+        $vatRepTurnover = self::getField($lineElement, "vatrepturnover");
+        if ($vatRepTurnover) {
+            $line->setVatRepTurnover(Util::parseMoney($vatRepTurnover, $bankTransaction->getCurrency()));
+        }
         $vatCode = self::getField($lineElement, "vatcode");
         if ($vatCode) {
             $line->setVatCode($vatCode);
@@ -144,11 +146,14 @@ class BankTransactionMapper extends BaseMapper
         Base $line
     ): void {
         $line->setId($lineElement->getAttribute("id"));
-        $line->setDescription(self::getField($lineElement, "description"));
         $value = self::getField($lineElement, 'value');
         $line->setValue(Util::parseMoney($value, $bankTransaction->getCurrency()));
         $line->setInvoiceNumber(self::getField($lineElement, "invoicenumber"));
 
+        $description = self::getField($lineElement, "description");
+        if ($description) {
+            $line->setDescription($description);
+        }
         $debitCredit = self::getField($lineElement, 'debitcredit');
         if ($debitCredit) {
             $line->setDebitCredit(new DebitCredit($debitCredit));

--- a/src/Mappers/BankTransactionMapper.php
+++ b/src/Mappers/BankTransactionMapper.php
@@ -86,11 +86,11 @@ class BankTransactionMapper extends BaseMapper
         $line->setAccount(self::getField($lineElement, "dim1"));
 
         $customerOrSupplierOrCostCenter = self::getField($lineElement, "dim2");
-        if ($customerOrSupplierOrCostCenter) {
+        if ($customerOrSupplierOrCostCenter !== null) {
             $line->setCustomerOrSupplierOrCostCenter($customerOrSupplierOrCostCenter);
         }
         $vatCode = self::getField($lineElement, "vatcode");
-        if ($vatCode) {
+        if ($vatCode !== null) {
             $line->setVatCode($vatCode);
         }
         $vatValue = self::getField($lineElement, "vatvalue");
@@ -106,7 +106,7 @@ class BankTransactionMapper extends BaseMapper
             $line->setVatRepValue(Util::parseMoney($vatRepValue, $bankTransaction->getCurrency()));
         }
         $projectOrAsset = self::getField($lineElement, "dim3");
-        if ($projectOrAsset) {
+        if ($projectOrAsset !== null) {
             $line->setProjectOrAsset($projectOrAsset);
         }
 
@@ -129,11 +129,11 @@ class BankTransactionMapper extends BaseMapper
             $line->setVatRepTurnover(Util::parseMoney($vatRepTurnover, $bankTransaction->getCurrency()));
         }
         $vatCode = self::getField($lineElement, "vatcode");
-        if ($vatCode) {
+        if ($vatCode !== null) {
             $line->setVatCode($vatCode);
         }
         $vatBalanceAccount = self::getField($lineElement, "dim1");
-        if ($vatBalanceAccount) {
+        if ($vatBalanceAccount !== null) {
             $line->setVatBalanceAccount($vatBalanceAccount);
         }
 
@@ -151,7 +151,7 @@ class BankTransactionMapper extends BaseMapper
         $line->setInvoiceNumber(self::getField($lineElement, "invoicenumber"));
 
         $description = self::getField($lineElement, "description");
-        if ($description) {
+        if ($description !== null) {
             $line->setDescription($description);
         }
         $debitCredit = self::getField($lineElement, 'debitcredit');
@@ -167,7 +167,7 @@ class BankTransactionMapper extends BaseMapper
             $line->setFreeChar($freeChar);
         }
         $comment = self::getField($lineElement, "comment");
-        if ($comment) {
+        if ($comment !== null) {
             $line->setComment($comment);
         }
     }
@@ -183,7 +183,7 @@ class BankTransactionMapper extends BaseMapper
             $line->setPerformanceCountry($performanceCountry);
         }
         $performanceVatNumber = self::getField($lineElement, "performancevatnumber");
-        if ($performanceVatNumber) {
+        if ($performanceVatNumber !== null) {
             $line->setPerformanceVatNumber($performanceVatNumber);
         }
         $performanceDate = self::getField($lineElement, "performancedate");

--- a/tests/UnitTests/ApiConnectors/BankTransactionApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BankTransactionApiConnectorTest.php
@@ -15,6 +15,7 @@ use PhpTwinfield\Secure\Connection;
 use PhpTwinfield\Services\ProcessXmlService;
 use PhpTwinfield\Transactions\BankTransactionLine\Detail;
 use PhpTwinfield\Transactions\BankTransactionLine\Total;
+use PhpTwinfield\Transactions\BankTransactionLine\Vat;
 use PHPUnit\Framework\TestCase;
 
 class BankTransactionApiConnectorTest extends TestCase
@@ -108,7 +109,7 @@ class BankTransactionApiConnectorTest extends TestCase
         $this->assertEquals("201700334", $banktransaction3->getNumber());
 
         $lines = $banktransaction3->getLines();
-        $this->assertEquals(3, count($lines));
+        $this->assertCount(3, $lines);
 
         /** @var Total $line */
         $line = $lines[0];
@@ -131,5 +132,67 @@ class BankTransactionApiConnectorTest extends TestCase
         $this->assertEquals("2017.123456", $line->getInvoiceNumber());
         $this->assertEquals("2017.123456", $line->getDescription());
         $this->assertEquals("2017.123456", $line->getComment());
+    }
+
+    public function testSendAllReturnsMappedObjectsAllLineTypes()
+    {
+        $response = Response::fromString(file_get_contents(
+            __DIR__."/resources/banktransaction-with-all-line-types.xml"
+        ));
+
+        $this->processXmlService->expects($this->once())
+            ->method("sendDocument")
+            ->willReturn($response);
+
+        $responses = $this->apiConnector->sendAll([$this->createBankTransaction()]);
+        $this->assertCount(1, $responses);
+        $response = $responses[0];
+
+        /** @var BankTransaction $banktransaction */
+        $banktransaction = $response->unwrap();
+
+        $this->assertEquals("BNK", $banktransaction->getCode());
+        $this->assertEquals("OFFICE001", $banktransaction->getOffice()->getCode());
+        $this->assertEquals("2017/09", $banktransaction->getPeriod());
+        $this->assertEquals(new Currency("EUR"), $banktransaction->getCurrency());
+        $this->assertEquals(Money::EUR(0), $banktransaction->getStartvalue());
+        $this->assertEquals(Money::EUR(12100), $banktransaction->getClosevalue());
+        $this->assertEquals(0, $banktransaction->getStatementnumber());
+        $this->assertEquals("201700001", $banktransaction->getNumber());
+
+        $lines = $banktransaction->getLines();
+        $this->assertCount(3, $lines);
+
+        /** @var Total $line */
+        $line = $lines[0];
+        $this->assertEquals("1", $line->getId());
+        $this->assertEquals(LineType::TOTAL(), $line->getLineType());
+        $this->assertEquals("1100", $line->getDim1());
+        $this->assertEquals("debit", $line->getDebitCredit());
+        $this->assertEquals(Money::EUR(12100), $line->getValue());
+
+        /** @var Detail $line */
+        $line = $lines[1];
+        $this->assertEquals("2", $line->getId());
+        $this->assertEquals(LineType::DETAIL(), $line->getLineType());
+        $this->assertEquals("2200", $line->getDim1());
+        $this->assertEquals("credit", $line->getDebitCredit());
+        $this->assertEquals(Money::EUR(10000), $line->getValue());
+        $this->assertEquals("My transaction", $line->getDescription());
+        $this->assertEquals("VH", $line->getVatCode());
+        $this->assertEquals(Money::EUR(2100), $line->getVatValue());
+        $this->assertEquals(null, $line->getInvoiceNumber());
+        $this->assertEquals(Money::EUR(2100), $line->getVatBaseValue());
+
+        /** @var Vat $line */
+        $line = $lines[2];
+        $this->assertEquals("3", $line->getId());
+        $this->assertEquals(LineType::VAT(), $line->getLineType());
+        $this->assertEquals("1502", $line->getDim1());
+        $this->assertEquals("credit", $line->getDebitCredit());
+        $this->assertEquals(Money::EUR(2100), $line->getValue());
+        $this->assertEquals("VH", $line->getVatCode());
+        $this->assertEquals(Money::EUR(10000), $line->getVatTurnover());
+        $this->assertEquals(Money::EUR(10000), $line->getVatBaseTurnover());
     }
 }

--- a/tests/UnitTests/ApiConnectors/BankTransactionApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BankTransactionApiConnectorTest.php
@@ -7,11 +7,14 @@ use Money\Money;
 use PhpTwinfield\ApiConnectors\BankTransactionApiConnector;
 use PhpTwinfield\BankTransaction;
 use PhpTwinfield\Enums\Destiny;
+use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\Exception;
 use PhpTwinfield\Office;
 use PhpTwinfield\Response\Response;
 use PhpTwinfield\Secure\Connection;
 use PhpTwinfield\Services\ProcessXmlService;
+use PhpTwinfield\Transactions\BankTransactionLine\Detail;
+use PhpTwinfield\Transactions\BankTransactionLine\Total;
 use PHPUnit\Framework\TestCase;
 
 class BankTransactionApiConnectorTest extends TestCase
@@ -103,5 +106,30 @@ class BankTransactionApiConnectorTest extends TestCase
         $this->assertEquals(Money::EUR(0), $banktransaction3->getClosevalue());
         $this->assertEquals(0, $banktransaction3->getStatementnumber());
         $this->assertEquals("201700334", $banktransaction3->getNumber());
+
+        $lines = $banktransaction3->getLines();
+        $this->assertEquals(3, count($lines));
+
+        /** @var Total $line */
+        $line = $lines[0];
+        $this->assertEquals("1", $line->getId());
+        $this->assertEquals(LineType::TOTAL(), $line->getLineType());
+        $this->assertEquals("1100", $line->getDim1());
+        $this->assertEquals("debit", $line->getDebitCredit());
+        $this->assertEquals(Money::EUR(0), $line->getValue());
+        $this->assertEquals("2017.123456", $line->getInvoiceNumber());
+        $this->assertEquals("2017.123456", $line->getDescription());
+        $this->assertEquals("2017.123456", $line->getComment());
+
+        /** @var Detail $line */
+        $line = $lines[1];
+        $this->assertEquals("2", $line->getId());
+        $this->assertEquals(LineType::DETAIL(), $line->getLineType());
+        $this->assertEquals("1800", $line->getDim1());
+        $this->assertEquals("debit", $line->getDebitCredit());
+        $this->assertEquals(Money::EUR(87), $line->getValue());
+        $this->assertEquals("2017.123456", $line->getInvoiceNumber());
+        $this->assertEquals("2017.123456", $line->getDescription());
+        $this->assertEquals("2017.123456", $line->getComment());
     }
 }

--- a/tests/UnitTests/ApiConnectors/resources/banktransaction-with-all-line-types.xml
+++ b/tests/UnitTests/ApiConnectors/resources/banktransaction-with-all-line-types.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<transactions result="1">
+    <transaction result="1" location="temporary">
+        <header>
+            <code name="Standaard bank" shortname="Standaard bank">BNK</code>
+            <office name="Office 001" shortname="Office 001">OFFICE001</office>
+            <period>2017/09</period>
+            <date>20170901</date>
+            <currency name="Euro" shortname="Euro">EUR</currency>
+            <startvalue>0.00</startvalue>
+            <closevalue>121.00</closevalue>
+            <origin>import</origin>
+            <user name="User" shortname="User">USER</user>
+            <regime>generic</regime>
+            <statementnumber>0</statementnumber>
+            <number>201700001</number>
+        </header>
+        <lines>
+            <line type="total" id="1">
+                <dim1 name="Standaard bank" shortname="" type="BAS" inuse="false" vatcode="" vatobligatory="false">1100</dim1>
+                <debitcredit>debit</debitcredit>
+                <value>121.00</value>
+                <rate>1</rate>
+                <basevalue>121.00</basevalue>
+                <reprate>1</reprate>
+                <repvalue>121.00</repvalue>
+                <matchstatus>notmatchable</matchstatus>
+            </line>
+            <line type="detail" id="2">
+                <dim1 name="Vraagposten" shortname="" type="BAS" inuse="true" vatcode="" vatobligatory="false">2200</dim1>
+                <debitcredit>credit</debitcredit>
+                <value>100.00</value>
+                <description>My transaction</description>
+                <vatcode name="Verkoop 21%" shortname="Verkoop 21%">VH</vatcode>
+                <vatvalue>21.00</vatvalue>
+                <rate>1</rate>
+                <basevalue>100.00</basevalue>
+                <reprate>1</reprate>
+                <repvalue>100.00</repvalue>
+                <currencydate/>
+                <invoicenumber/>
+                <vatbasevalue>21.00</vatbasevalue>
+                <matchstatus>notmatchable</matchstatus>
+            </line>
+            <line type="vat" id="3">
+                <debitcredit>credit</debitcredit>
+                <value>21.00</value>
+                <vatcode name="Verkoop 21%" shortname="Verkoop 21%">VH</vatcode>
+                <rate>1</rate>
+                <basevalue>21.00</basevalue>
+                <reprate>1</reprate>
+                <repvalue>21.00</repvalue>
+                <baseline>1</baseline>
+                <vatturnover>100.00</vatturnover>
+                <vatbaseturnover>100.00</vatbaseturnover>
+                <dim1 name="BTW af te dragen 21%" shortname="" type="BAS" inuse="true" vatcode="" vatobligatory="false">1502</dim1>
+                <matchstatus>notmatchable</matchstatus>
+            </line>
+        </lines>
+    </transaction>
+</transactions>


### PR DESCRIPTION
Some fields could not be parsed, as they are not part of the `BankTransactionLine` classes. Examples of such fields are `currencydate` and `basevalue`.

~~Furthermore, no example XML line for the VAT type is available, so no tests have been added for the parsing of such lines.~~ This has now been fixed, given that a new example XML response containing all line types has been provided by @Daanvm.

This PR fixes #71.