### PR TITLE
Added support for processing all objects when using 'sendAll()'.

### DIFF
--- a/src/ApiConnectors/BankTransactionApiConnector.php
+++ b/src/ApiConnectors/BankTransactionApiConnector.php
@@ -21,12 +21,12 @@ class BankTransactionApiConnector extends BaseApiConnector
      */
     public function send(BankTransaction $bankTransaction): BankTransaction
     {
-        $result = $this->sendAll([$bankTransaction]);
+        $bankTransactionResponses = $this->sendAll([$bankTransaction]);
 
-        Assert::count($result, 1);
+        Assert::count($bankTransactionResponses, 1);
 
-        foreach ($result as $each) {
-            return $each->unwrap();
+        foreach ($bankTransactionResponses as $bankTransactionResponse) {
+            return $bankTransactionResponse->unwrap();
         }
     }
 

--- a/src/ApiConnectors/BankTransactionApiConnector.php
+++ b/src/ApiConnectors/BankTransactionApiConnector.php
@@ -6,7 +6,7 @@ use PhpTwinfield\BankTransaction;
 use PhpTwinfield\DomDocuments\BankTransactionDocument;
 use PhpTwinfield\Exception;
 use PhpTwinfield\Mappers\BankTransactionMapper;
-use PhpTwinfield\Response\IndividualMappedResponse;
+use PhpTwinfield\Response\MappedResponseCollection;
 use PhpTwinfield\Response\Response;
 use Webmozart\Assert\Assert;
 
@@ -21,21 +21,21 @@ class BankTransactionApiConnector extends BaseApiConnector
      */
     public function send(BankTransaction $bankTransaction): BankTransaction
     {
-        $responses = $this->sendAll([$bankTransaction]);
+        $result = $this->sendAll([$bankTransaction]);
 
-        Assert::count($responses, 1);
+        Assert::count($result, 1);
 
-        foreach ($responses as $response) {
-            return $response->unwrap();
+        foreach ($result as $each) {
+            return $each->unwrap();
         }
     }
 
     /**
      * @param BankTransaction[] $bankTransactions
-     * @return IndividualMappedResponse[]|array
+     * @return MappedResponseCollection
      * @throws Exception
      */
-    public function sendAll(array $bankTransactions): iterable
+    public function sendAll(array $bankTransactions): MappedResponseCollection
     {
         Assert::allIsInstanceOf($bankTransactions, BankTransaction::class);
 

--- a/src/ApiConnectors/CustomerApiConnector.php
+++ b/src/ApiConnectors/CustomerApiConnector.php
@@ -8,7 +8,7 @@ use PhpTwinfield\Exception;
 use PhpTwinfield\Mappers\CustomerMapper;
 use PhpTwinfield\Office;
 use PhpTwinfield\Request as Request;
-use PhpTwinfield\Response\IndividualMappedResponse;
+use PhpTwinfield\Response\MappedResponseCollection;
 use PhpTwinfield\Response\Response;
 use Webmozart\Assert\Assert;
 
@@ -106,10 +106,10 @@ class CustomerApiConnector extends BaseApiConnector
 
     /**
      * @param Customer[] $customers
-     * @return IndividualMappedResponse[]|iterable
+     * @return MappedResponseCollection
      * @throws Exception
      */
-    public function sendAll(array $customers): iterable
+    public function sendAll(array $customers): MappedResponseCollection
     {
         Assert::allIsInstanceOf($customers, Customer::class);
 

--- a/src/ApiConnectors/CustomerApiConnector.php
+++ b/src/ApiConnectors/CustomerApiConnector.php
@@ -95,12 +95,12 @@ class CustomerApiConnector extends BaseApiConnector
      */
     public function send(Customer $customer): Customer
     {
-        $result = $this->sendAll([$customer]);
+        $customerResponses = $this->sendAll([$customer]);
 
-        Assert::count($result, 1);
+        Assert::count($customerResponses, 1);
 
-        foreach ($result as $each) {
-            return $each->unwrap();
+        foreach ($customerResponses as $customerResponse) {
+            return $customerResponse->unwrap();
         }
     }
 

--- a/src/ApiConnectors/TransactionApiConnector.php
+++ b/src/ApiConnectors/TransactionApiConnector.php
@@ -9,6 +9,7 @@ use PhpTwinfield\DomDocuments\TransactionsDocument;
 use PhpTwinfield\Mappers\TransactionMapper;
 use PhpTwinfield\BaseTransaction;
 use PhpTwinfield\Response\IndividualMappedResponse;
+use PhpTwinfield\Response\MappedResponseCollection;
 use PhpTwinfield\Response\Response;
 use Webmozart\Assert\Assert;
 
@@ -65,10 +66,10 @@ class TransactionApiConnector extends BaseApiConnector
      * Sends a list of Transaction instances to Twinfield to add or update.
      *
      * @param BaseTransaction[] $transactions
-     * @return IndividualMappedResponse[]
+     * @return MappedResponseCollection
      * @throws Exception
      */
-    public function sendAll(array $transactions): array
+    public function sendAll(array $transactions): MappedResponseCollection
     {
         Assert::allIsInstanceOf($transactions, BaseTransaction::class);
 

--- a/src/Response/IndividualMappedResponse.php
+++ b/src/Response/IndividualMappedResponse.php
@@ -2,6 +2,8 @@
 
 namespace PhpTwinfield\Response;
 
+use PhpTwinfield\Exception;
+
 class IndividualMappedResponse
 {
     /**
@@ -17,6 +19,16 @@ class IndividualMappedResponse
     {
         $this->response = $response;
         $this->mapper = $mapper;
+    }
+
+    public function isSuccessful(): bool
+    {
+        try {
+            $this->response->assertSuccessful();
+        } catch (Exception $e) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/Response/MappedResponseCollection.php
+++ b/src/Response/MappedResponseCollection.php
@@ -2,6 +2,8 @@
 
 namespace PhpTwinfield\Response;
 
+use Webmozart\Assert\Assert;
+
 class MappedResponseCollection extends \ArrayObject
 {
     /**
@@ -30,7 +32,7 @@ class MappedResponseCollection extends \ArrayObject
     /**
      * @return IndividualMappedResponse[]
      */
-    public function getSuccessfulResponses()
+    public function getSuccessfulResponses(): array
     {
         return $this->getResponses(true);
     }
@@ -48,14 +50,14 @@ class MappedResponseCollection extends \ArrayObject
     /**
      * @return IndividualMappedResponse[]
      */
-    public function getFailedResponses()
+    public function getFailedResponses(): array
     {
         return $this->getResponses(false);
     }
 
-    public function assertAllSuccessful()
+    public function assertAllSuccessful(): void
     {
-        assert($this->countResponses(false) === 0);
+        Assert::eq($this->countResponses(false), 0);
     }
 
     /**
@@ -63,7 +65,7 @@ class MappedResponseCollection extends \ArrayObject
      *
      * @return IndividualMappedResponse[]
      */
-    private function getResponses(bool $successful)
+    private function getResponses(bool $successful): array
     {
         $responses = [];
 

--- a/src/Response/MappedResponseCollection.php
+++ b/src/Response/MappedResponseCollection.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace PhpTwinfield\Response;
+
+class MappedResponseCollection extends \ArrayObject
+{
+    /**
+     * @param mixed $value
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function append($value): void
+    {
+        if (!($value instanceof IndividualMappedResponse)) {
+            throw new \InvalidArgumentException("Value has to be an object of type " . IndividualMappedResponse::class);
+        }
+        parent::append($value);
+    }
+
+    public function hasSuccessfulResponses(): bool
+    {
+        return $this->countResponses(true) > 0;
+    }
+
+    public function countSuccessfulResponses(): int
+    {
+        return $this->countResponses(true);
+    }
+
+    /**
+     * @return IndividualMappedResponse[]
+     */
+    public function getSuccessfulResponses()
+    {
+        return $this->getResponses(true);
+    }
+
+    public function hasFailedResponses(): bool
+    {
+        return $this->countResponses(false) > 0;
+    }
+
+    public function countFailedResponses(): int
+    {
+        return $this->countResponses(false);
+    }
+
+    /**
+     * @return IndividualMappedResponse[]
+     */
+    public function getFailedResponses()
+    {
+        return $this->getResponses(false);
+    }
+
+    public function assertAllSuccessful()
+    {
+        assert($this->countResponses(false) === 0);
+    }
+
+    /**
+     * @var bool $successful
+     *
+     * @return IndividualMappedResponse[]
+     */
+    private function getResponses(bool $successful)
+    {
+        $responses = [];
+
+        /** @var IndividualMappedResponse $response */
+        foreach ($this as $response) {
+            if ($response->isSuccessful() === $successful) {
+                $responses[] = $response;
+            }
+        }
+
+        return $responses;
+    }
+
+    private function countResponses(bool $successful): int
+    {
+        $count = 0;
+
+        /** @var IndividualMappedResponse $response */
+        foreach ($this as $response) {
+            if ($response->isSuccessful() === $successful) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/src/Response/MappedResponseCollection.php
+++ b/src/Response/MappedResponseCollection.php
@@ -55,6 +55,9 @@ class MappedResponseCollection extends \ArrayObject
         return $this->getResponses(false);
     }
 
+    /**
+     * @throws \InvalidArgumentException
+     */
     public function assertAllSuccessful(): void
     {
         Assert::eq($this->countResponses(false), 0);

--- a/tests/UnitTests/Request/MappedResponseCollectionUnitTest.php
+++ b/tests/UnitTests/Request/MappedResponseCollectionUnitTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpTwinfield\UnitTests;
+
+use PhpTwinfield\ApiConnectors\BankTransactionApiConnector;
+use PhpTwinfield\Response\Response;
+use PhpTwinfield\Services\ProcessXmlService;
+use PHPUnit\Framework\TestCase;
+
+class MappedResponseCollectionUnitTest extends TestCase
+{
+    /**
+     * @var BankTransactionApiConnector
+     */
+    protected $apiConnector;
+
+    /**
+     * @var ProcessXmlService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $processXmlService;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->processXmlService = $this->createPartialMock(ProcessXmlService::class, []);
+    }
+
+    public function testMappedResponseCollection()
+    {
+        $response = $this->createFakeResponse();
+        $collection = $this->processXmlService->mapAll([$response], "someResource", function() {});
+
+        $this->assertTrue($collection->hasFailedResponses());
+        $this->assertEquals(2, $collection->countFailedResponses());
+        $this->assertCount(2, $collection->getFailedResponses());
+        $this->assertTrue($collection->hasSuccessfulResponses());
+        $this->assertEquals(3, $collection->countSuccessfulResponses());
+        $this->assertCount(3, $collection->getSuccessfulResponses());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $collection->append("somethingOtherThanAnIndividualMappedResponse");
+    }
+
+    public function createFakeResponse()
+    {
+        return Response::fromString("
+<someResources result='0'>
+    <someResource result='1'></someResource>
+    <someResource result='0'></someResource>
+    <someResource result='1'></someResource>
+    <someResource result='0'></someResource>
+    <someResource result='1'></someResource>
+</someResources>");
+    }
+}

--- a/tests/UnitTests/Request/MappedResponseCollectionUnitTest.php
+++ b/tests/UnitTests/Request/MappedResponseCollectionUnitTest.php
@@ -40,6 +40,7 @@ class MappedResponseCollectionUnitTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $collection->append("somethingOtherThanAnIndividualMappedResponse");
+        $collection->assertAllSuccessful();
     }
 
     public function createFakeResponse()


### PR DESCRIPTION
Instead of stopping as soon as an object contains an error, now all objects that are returned by Twinfield will be processed. All `IndividualMappedResponse` objects will furthermore be wrapped into a `MappedResponseCollection` object. This class has methods to easily determine whether the objects returned by Twinfield have errors/are successful, how many of them have errors/are successful and return the `IndividualMappedResponse` objects that have errors/are successful.

This PR fixes #73.