### PR TITLE
Added support for retrying requests that return the SSL error.

### DIFF
--- a/src/ApiConnectors/BaseApiConnector.php
+++ b/src/ApiConnectors/BaseApiConnector.php
@@ -19,6 +19,7 @@ abstract class BaseApiConnector
      * @var string[]
      */
     private const RETRY_REQUEST_EXCEPTION_MESSAGES = [
+        "Error Fetching http headers",
         "SSL: Connection reset by peer",
         "Your logon credentials are not valid anymore. Try to log on again."
     ];

--- a/src/Services/ProcessXmlService.php
+++ b/src/Services/ProcessXmlService.php
@@ -46,6 +46,7 @@ class ProcessXmlService extends BaseService
      *
      * @see \PhpTwinfield\ApiConnectors\BaseApiConnector::sendXmlDocuments()
      * @throws \SoapFault
+     * @throws \ErrorException
      */
     public function sendDocument(\DOMDocument $document): Response
     {


### PR DESCRIPTION
This Pull Request fixes #76 by adding the functionality of automatically retrying request in case of the specified SSL error. It will retry a maximum of three times (defined by a constant), after which it will throw an exception anyway.

Because the amount of error messages that we want to retry automatically might increase in the future, I figured I could best create a constant array with these messages, such that the logic of checking whether the request should be retried can be embedded in a for-loop. Thankfully, PHP 7.1 features catching multiple exception class in one catch block, which prevented the need for duplicating code.

I furthermore modified the `\PhpTwinfield\UnitTests\BaseApiConnectorTest` to work for both the SoapFault and ErrorException exception types, and for all error messages that should be retried, using `@dataProvider`'s. It is also tested that after three times, no more retries will be attempted.