### PR TITLE
Require only a refresh token for OAuth2 authentication

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ username and password authentication, the `\PhpTwinfield\Secure\WebservicesAuthe
 $connection = new Secure\WebservicesAuthentication("username", "password", "organization");
 ```
 
-In order to use OAuth2 to authenticate with Twinfield, one should use the `\PhpTwinfield\Secure\Provider\OAuthProvider` to retrieve an `\League\OAuth2\Client\Token\AccessToken` object. Next to the `OAuthProvider` and `AccessToken`, it is required to set up a default `\PhpTwinfield\Office`, that will be used during requests to Twinfield. **Please note:** when a different office is specified when sending a request through one of the `ApiConnectors`, this Office will override the default.
+In order to use OAuth2 to authenticate with Twinfield, one should use the `\PhpTwinfield\Secure\Provider\OAuthProvider` to retrieve an `\League\OAuth2\Client\Token\AccessToken` object, and extract the refresh token from this object. Furthermore, it is required to set up a default `\PhpTwinfield\Office`, that will be used during requests to Twinfield. **Please note:** when a different office is specified when sending a request through one of the `ApiConnectors`, this Office will override the default.
 
 Using this information, we can create an instance of the `\PhpTwinfield\Secure\OpenIdConnectAuthentication` class, as follows:
 
@@ -31,10 +31,11 @@ $provider    = new OAuthProvider([
     'clientSecret' => 'someClientSecret',
     'redirectUri'  => 'https://example.org/'
 ]);
-$accessToken = $provider->getAccessToken("authorization_code", ["code" => ...]);
-$office      = \PhpTwinfield\Office::fromCode("someOfficeCode");
+$accessToken  = $provider->getAccessToken("authorization_code", ["code" => ...]);
+$refreshToken = $accessToken->getRefreshToken();
+$office       = \PhpTwinfield\Office::fromCode("someOfficeCode");
 
-$connection  = new \PhpTwinfield\Secure\OpenIdConnectAuthentication($provider, $accessToken, $office);
+$connection  = new \PhpTwinfield\Secure\OpenIdConnectAuthentication($provider, $refreshToken, $office);
 ```
 For more information about retrieving the initial `AccessToken`, please refer to: https://github.com/thephpleague/oauth2-client#usage
 

--- a/src/Secure/OpenIdConnectAuthentication.php
+++ b/src/Secure/OpenIdConnectAuthentication.php
@@ -39,16 +39,15 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
      */
     private $cluster;
 
+    /**
+     * The office code that is part of the Office object that is passed here will be
+     * the default office code used during requests. If an office code is included in
+     * the SOAP request body, this will always take precedence over this default.
+     */
     public function __construct(OAuthProvider $provider, string $refreshToken, Office $office)
     {
         $this->provider     = $provider;
         $this->refreshToken = $refreshToken;
-
-        /*
-         * The office code that is part of the Office object that is passed here will be
-         * the default office code used during requests. If an office code is included in
-         * the SOAP request body, this will always take precedence over this default.
-         */
         $this->office      = $office;
     }
 

--- a/tests/UnitTests/Secure/OpenIdConnectionAuthenticationTest.php
+++ b/tests/UnitTests/Secure/OpenIdConnectionAuthenticationTest.php
@@ -27,17 +27,6 @@ class OpenIdConnectionAuthenticationTest extends TestCase
             ->getMock();
     }
 
-    public function testConstructWithIncompleteAccessToken()
-    {
-        $this->expectException(OAuthException::class);
-        $this->expectExceptionMessage("AccessToken does not contain a refresh token.");
-
-        $provider = $this->createMock(OAuthProvider::class);
-        $token    = $this->createMock(AccessToken::class);
-        $office   = $this->createMock(Office::class);
-        new OpenIdConnectAuthentication($provider, $token, $office);
-    }
-
     public function testValidTokenLogin()
     {
         $this->openIdConnect->expects($this->once())


### PR DESCRIPTION
This PR improves the implementation of OAuth2 authentication.

Previously, an `\League\OAuth2\Client\Token\AccessToken` was expected when creating an instance of the `\PhpTwinfield\Secure\OpenIdConnectAuthentication` class. This `AccessToken` has to contain an access token.

The problem is that only providing a refresh token is enough, as a valid access token can be retrieved using the refresh token. This has now been implemented in the code.