### PR TITLE
Fix for the 'twf.user' scope and 'getResourceOwner' method

### DIFF
--- a/src/Secure/Provider/ResourceOwner.php
+++ b/src/Secure/Provider/ResourceOwner.php
@@ -21,7 +21,7 @@ class ResourceOwner implements ResourceOwnerInterface
      */
     public function getId(): string
     {
-        return $this->response["id"];
+        return $this->response["sub"];
     }
 
     /**

--- a/tests/UnitTests/Secure/Provider/OAuthProviderTest.php
+++ b/tests/UnitTests/Secure/Provider/OAuthProviderTest.php
@@ -34,7 +34,7 @@ class OAuthProviderTest extends TestCase
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'https://example.org/'
         ]);
-        $this->token    = $this->createMock(AccessToken::class);
+        $this->token = $this->createMock(AccessToken::class);
     }
 
     public function testGetBaseAccessTokenUrl()
@@ -122,14 +122,10 @@ class OAuthProviderTest extends TestCase
 
     public function testGetResourceOwnerDetails()
     {
-        /* TODO: Make this test actually run when the 'getResourceOwner' method is fixed. */
-        $this->assertTrue(True);
-        return;
-
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->any())
             ->method("getBody")
-            ->willReturn('{"id": "someId", "name": "someName"}');
+            ->willReturn('{"sub": "someId", "twf.organisationId": "someOrganisationId"}');
         $response->expects($this->any())
             ->method("getHeader")
             ->willReturn(['content-type' => 'json']);
@@ -148,6 +144,6 @@ class OAuthProviderTest extends TestCase
 
         $account = $this->provider->getResourceOwner($this->token);
         $this->assertEquals("someId", $account->getId());
-        $this->assertEquals(["id" => "someId", "name" => "someName"], $account->toArray());
+        $this->assertEquals(["sub" => "someId", "twf.organisationId" => "someOrganisationId"], $account->toArray());
     }
 }


### PR DESCRIPTION
After some communication with Twinfield, it became apparent that the `twf.user` scope was not working, because the `openid` scope was missing. Unfortunately, this was not stated in their documentation (which will be updated). Furthermore, the problem with the `getResourceOwner` method is fixed. It can be called only when the `openid` scope is used. The `twf.user` scope can optionally be passed to retrieve more information from the `getResourceOwner` method.

Changes:
- Added the `openid` scope as constant.
- Added the `openid` scope as a default scope, as the default scopes should include those scopes that are necessary to request the details of the resource owner.
- Made sure to allow the `twf.user` scope again, but only if the `openid` scope is present.
- Modified the `ResourceOwner` class to match the data that Twinfield returns.