### PR TITLE
Add `BookingReferenceInterface` for identifying bookings

### DIFF
--- a/src/BookingReference.php
+++ b/src/BookingReference.php
@@ -1,0 +1,60 @@
+<?php
+namespace PhpTwinfield;
+
+final class BookingReference implements BookingReferenceInterface
+{
+    /**
+     * @var Office
+     */
+    private $office;
+
+    /**
+     * @var int
+     */
+    private $number;
+
+    /**
+     * @var string
+     */
+    private $code;
+
+    public static function fromMatchReference(MatchReferenceInterface $matchReference): BookingReferenceInterface
+    {
+        return new self(
+            $matchReference->getOffice(),
+            $matchReference->getCode(),
+            $matchReference->getNumber()
+        );
+    }
+
+    public function __construct(Office $office, string $code, int $number)
+    {
+        $this->office = $office;
+        $this->code   = $code;
+        $this->number = $number;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOffice(): Office
+    {
+        return $this->office;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNumber(): int
+    {
+        return $this->number;
+    }
+}

--- a/src/BookingReferenceInterface.php
+++ b/src/BookingReferenceInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpTwinfield;
+
+/**
+ * The values provided by this interface uniquely define a booking (e.g. SalesTransaction, BankTransaction, etc.) in
+ * Twinfield and can be used when a reference to the booking is needed, for example when deleting a booking.
+ *
+ * You can use the provided MatchReference object or you can implement this directly on one of your entities / domain
+ * models.
+ */
+interface BookingReferenceInterface
+{
+    /**
+     * References the office in which the transaction was booked.
+     */
+    public function getOffice(): Office;
+
+    /**
+     * References the daybook on which the transaction was booked.
+     */
+    public function getCode(): string;
+
+    /**
+     * References the transaction.
+     */
+    public function getNumber(): int;
+}

--- a/src/BookingReferenceInterface.php
+++ b/src/BookingReferenceInterface.php
@@ -6,8 +6,10 @@ namespace PhpTwinfield;
  * The values provided by this interface uniquely define a booking (e.g. SalesTransaction, BankTransaction, etc.) in
  * Twinfield and can be used when a reference to the booking is needed, for example when deleting a booking.
  *
- * You can use the provided MatchReference object or you can implement this directly on one of your entities / domain
+ * You can use the provided BookingReference object or you can implement this directly on one of your entities / domain
  * models.
+ *
+ * @see BookingReference
  */
 interface BookingReferenceInterface
 {

--- a/src/MatchReference.php
+++ b/src/MatchReference.php
@@ -5,46 +5,46 @@ namespace PhpTwinfield;
 final class MatchReference implements MatchReferenceInterface
 {
     /**
-     * @var Office
+     * @var BookingReferenceInterface
      */
-    private $office;
-
-    /**
-     * @var int
-     */
-    private $number;
-
-    /**
-     * @var string
-     */
-    private $code;
+    private $bookingReference;
 
     /**
      * @var int
      */
     private $lineId;
 
+    public static function fromBookingReference(
+        BookingReferenceInterface $bookingReference,
+        int $lineId
+    ): MatchReferenceInterface {
+        return new self(
+            $bookingReference->getOffice(),
+            $bookingReference->getCode(),
+            $bookingReference->getNumber(),
+            $lineId
+        );
+    }
+
     public function __construct(Office $office, string $code, int $number, int $lineId)
     {
-        $this->office = $office;
-        $this->code   = $code;
-        $this->number = $number;
+        $this->bookingReference = new BookingReference($office, $code, $number);
         $this->lineId = $lineId;
     }
 
     public function getOffice(): Office
     {
-        return $this->office;
+        return $this->bookingReference->getOffice();
     }
 
     public function getCode(): string
     {
-        return $this->code;
+        return $this->bookingReference->getCode();
     }
 
     public function getNumber(): int
     {
-        return $this->number;
+        return $this->bookingReference->getNumber();
     }
 
     public function getLineId(): int

--- a/src/MatchReferenceInterface.php
+++ b/src/MatchReferenceInterface.php
@@ -10,7 +10,9 @@ namespace PhpTwinfield;
  * You can use the provided MatchReference object or you can implement this directly on one of your entities / domain
  * models.
  *
- * @see https://c3.twinfield.com/webservices/documentation/#/ApiReference/Miscellaneous/Matching
+ * @see MatchReference
+ *
+ * @link https://c3.twinfield.com/webservices/documentation/#/ApiReference/Miscellaneous/Matching
  */
 interface MatchReferenceInterface
 {

--- a/tests/UnitTests/BookingReferenceUnitTest.php
+++ b/tests/UnitTests/BookingReferenceUnitTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpTwinfield\UnitTests;
+
+use PhpTwinfield\BookingReference;
+use PhpTwinfield\BookingReferenceInterface;
+use PhpTwinfield\MatchReference;
+use PhpTwinfield\Office;
+use PHPUnit\Framework\TestCase;
+
+class BookingReferenceUnitTest extends TestCase
+{
+    public function testBookingReferenceImplementsInterface()
+    {
+        self::assertInstanceOf(
+            BookingReferenceInterface::class,
+            new BookingReference(Office::fromCode('XXX'), 'code', 1234)
+        );
+    }
+
+    public function testConstructionWorks()
+    {
+        $matchReference = new BookingReference(Office::fromCode('XXX'), 'code', 1234);
+
+        self::assertSame('XXX', $matchReference->getOffice()->getCode());
+        self::assertSame('code', $matchReference->getCode());
+        self::assertSame(1234, $matchReference->getNumber());
+    }
+
+    public function testFromMatchingReferenceWorks()
+    {
+        $matchReference = BookingReference::fromMatchReference(
+            new MatchReference(Office::fromCode('YYY-10'), 'edoc', 4321000, 25)
+        );
+
+        self::assertSame('YYY-10', $matchReference->getOffice()->getCode());
+        self::assertSame('edoc', $matchReference->getCode());
+        self::assertSame(4321000, $matchReference->getNumber());
+    }
+}

--- a/tests/UnitTests/MatchReferenceUnitTest.php
+++ b/tests/UnitTests/MatchReferenceUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PhpTwinfield\UnitTests;
+
+use PhpTwinfield\BookingReference;
+use PhpTwinfield\BookingReferenceInterface;
+use PhpTwinfield\MatchReference;
+use PhpTwinfield\MatchReferenceInterface;
+use PhpTwinfield\Office;
+use PHPUnit\Framework\TestCase;
+
+class MatchReferenceUnitTest extends TestCase
+{
+    public function testMatchReferenceImplementsInterface()
+    {
+        self::assertInstanceOf(
+            MatchReferenceInterface::class,
+            new MatchReference(Office::fromCode('XXX'), 'code', 1234, 1)
+        );
+    }
+
+    public function testMatchReferenceDoesNotImplementBookingInterface()
+    {
+        self::assertNotInstanceOf(
+            BookingReferenceInterface::class,
+            new MatchReference(Office::fromCode('XXX'), 'code', 1234, 1)
+        );
+    }
+
+    public function testConstructionWorks()
+    {
+        $matchReference = new MatchReference(Office::fromCode('XXX'), 'code', 1234, 1);
+
+        self::assertSame('XXX', $matchReference->getOffice()->getCode());
+        self::assertSame('code', $matchReference->getCode());
+        self::assertSame(1234, $matchReference->getNumber());
+        self::assertSame(1, $matchReference->getLineId());
+    }
+
+    public function testFromBookingReferenceWorks()
+    {
+        $matchReference = MatchReference::fromBookingReference(
+            new BookingReference(Office::fromCode('YYY-10'), 'edoc', 4321000),
+            20
+        );
+
+        self::assertSame('YYY-10', $matchReference->getOffice()->getCode());
+        self::assertSame('edoc', $matchReference->getCode());
+        self::assertSame(4321000, $matchReference->getNumber());
+        self::assertSame(20, $matchReference->getLineId());
+    }
+}


### PR DESCRIPTION
Deleting transactions, statements, etc. is done using a reference to
that object. However, the existing `MatchReferenceInterface` does not
suffice for this, since it references a specific line within such an
object.

Therefore `BookingReferenceInterface` was added to unqiuely identify a
booking.

`BookingReferenceInterface` is not extended by `MatchReferenceInterface`
on purpose, since we don't want anyone to accidentally pass a
`MatchReferenceInterface` to a delete method, expecting the specific
line to be deleted, but it actually deletes the entire transaction.
Usage of `BookingReferenceInterface` should be explicit.

Ease of use methods `BookingReference::fromMatchReference()` and
`MatchReference::fromBookingReference()` have been added.