### PR TITLE
Add psr/log and have `BaseApiConnector` log info, debug and error logs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "ext-soap": "*",
     "moneyphp/money": "^3.0",
     "myclabs/php-enum": "^1.5",
+    "psr/log": "^1.0",
     "webmozart/assert": "^1.2"
   },
   "suggest": {

--- a/src/ApiConnectors/BaseApiConnector.php
+++ b/src/ApiConnectors/BaseApiConnector.php
@@ -11,7 +11,6 @@ use PhpTwinfield\Services\ProcessXmlService;
 use PhpTwinfield\Util;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerTrait;
 
 abstract class BaseApiConnector implements LoggerAwareInterface
 {

--- a/src/ApiConnectors/BaseApiConnector.php
+++ b/src/ApiConnectors/BaseApiConnector.php
@@ -109,10 +109,10 @@ abstract class BaseApiConnector implements LoggerAwareInterface
             return;
         }
 
-        $message = sprintf(
-            "Sending request to Twinfield.%s",
-            $this->numRetries > 0 ? ' (attempt ' . ($this->numRetries + 1) . ')' : ''
-        );
+        $message = "Sending request to Twinfield.";
+        if ($this->numRetries > 0) {
+            $message .= ' (attempt ' . ($this->numRetries + 1) . ')';
+        }
 
         $this->logger->debug(
             $message,

--- a/src/Util.php
+++ b/src/Util.php
@@ -100,4 +100,20 @@ final class Util
 
         return in_array($trait, $traits);
     }
+
+    public static function getPrettyXml(\DOMDocument $document): string
+    {
+        $oldPreserveWhiteSpace = $document->preserveWhiteSpace;
+        $oldFormatOutput = $document->formatOutput;
+
+        $document->preserveWhiteSpace = false;
+        $document->formatOutput = true;
+
+        $xml_string = $document->saveXML();
+
+        $document->preserveWhiteSpace = $oldPreserveWhiteSpace;
+        $document->formatOutput = $oldFormatOutput;
+
+        return $xml_string ?: '';
+    }
 }

--- a/tests/UnitTests/ApiConnectors/BaseApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BaseApiConnectorTest.php
@@ -9,7 +9,6 @@ use PhpTwinfield\Response\Response;
 use PhpTwinfield\Secure\AuthenticatedConnection;
 use PhpTwinfield\Services\ProcessXmlService;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use Psr\Log\LogLevel;

--- a/tests/UnitTests/ApiConnectors/BaseApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BaseApiConnectorTest.php
@@ -9,9 +9,15 @@ use PhpTwinfield\Response\Response;
 use PhpTwinfield\Secure\AuthenticatedConnection;
 use PhpTwinfield\Services\ProcessXmlService;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+use Psr\Log\LogLevel;
 
-class BaseApiConnectorTest extends TestCase
+class BaseApiConnectorTest extends TestCase implements LoggerInterface
 {
+    use LoggerTrait;
+
     /**
      * @var AuthenticatedConnection|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -26,6 +32,11 @@ class BaseApiConnectorTest extends TestCase
      * @var ProcessXmlService|\PHPUnit_Framework_MockObject_MockObject
      */
     private $client;
+
+    /**
+     * @var mixed[][]
+     */
+    private $logs;
 
     protected function setUp()
     {
@@ -71,6 +82,155 @@ class BaseApiConnectorTest extends TestCase
     {
         $reflectionConstant = new \ReflectionClassConstant(BaseApiConnector::class,"MAX_RETRIES");
         return $reflectionConstant->getValue();
+    }
+
+    public function testSendDocumentLogsRequestAndResponse()
+    {
+        $request_document = new \DOMDocument();
+        $request_document->loadXML('<dimension>value</dimension>');
+
+        $response = Response::fromString('<dimension result="1">value</dimension>');
+
+        $this->connection->expects($this->any())
+            ->method("getAuthenticatedClient")
+            ->with(Services::PROCESSXML())
+            ->willReturn($this->client);
+
+        $this->client->expects($this->any())
+            ->method("sendDocument")
+            ->willReturn($response);
+
+        $this->service->setLogger($this);
+        $this->service->sendXmlDocument($request_document);
+
+        self::assertCount(2, $this->logs);
+
+        [$level, $message, $context] = $this->logs[0];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Sending request to Twinfield.', $message);
+        self::assertSame($this->completeXml('<dimension>value</dimension>'), $context['document_xml']);
+
+        [$level, $message, $context] = $this->logs[1];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Received response from Twinfield.', $message);
+        self::assertSame($this->completeXml('<dimension result="1">value</dimension>'), $context['document_xml']);
+    }
+
+    private function completeXml(string $xml): string
+    {
+        return sprintf(
+            '<?xml version="1.0"?>%s%s%s',
+            \PHP_EOL,
+            $xml,
+            \PHP_EOL
+        );
+    }
+
+    /**
+     * Used to keep track of the logs created by the API connector
+     *
+     * @inheritdoc
+     */
+    public function log($level, $message, array $context = array())
+    {
+        $this->logs[] = [$level, $message, $context];
+    }
+
+    /**
+     * @dataProvider soapFaultProvider
+     * @dataProvider errorExceptionProvider
+     */
+    public function testSendDocumentLogsRetries(\Throwable $e)
+    {
+        $request_document = new \DOMDocument();
+        $request_document->loadXML('<dimension>value</dimension>');
+
+        $response = Response::fromString('<dimension result="1">value</dimension>');
+
+        $this->connection->expects($this->any())
+            ->method("getAuthenticatedClient")
+            ->with(Services::PROCESSXML())
+            ->willReturn($this->client);
+
+        $this->client->expects($this->any())
+            ->method("sendDocument")
+            ->will($this->onConsecutiveCalls(
+                $this->throwException($e),
+                $this->throwException($e),
+                $this->returnValue($response)
+            ));
+
+        $this->service->setLogger($this);
+        $this->service->sendXmlDocument($request_document);
+
+
+        self::assertCount(6, $this->logs);
+
+        [$level, $message, $context] = $this->logs[0];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Sending request to Twinfield.', $message);
+        self::assertSame($this->completeXml('<dimension>value</dimension>'), $context['document_xml']);
+
+        [$level, $message, $context] = $this->logs[1];
+        self::assertSame(LogLevel::INFO, $level);
+        self::assertSame("Retrying request. Reason for initial failure: {$e->getMessage()}", $message);
+        self::assertEmpty($context);
+
+        [$level, $message, $context] = $this->logs[2];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Sending request to Twinfield. (attempt 2)', $message);
+        self::assertSame($this->completeXml('<dimension>value</dimension>'), $context['document_xml']);
+
+        [$level, $message, $context] = $this->logs[3];
+        self::assertSame(LogLevel::INFO, $level);
+        self::assertSame("Retrying request. Reason for initial failure: {$e->getMessage()}", $message);
+        self::assertEmpty($context);
+        self::assertEmpty($context);
+
+        [$level, $message, $context] = $this->logs[4];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Sending request to Twinfield. (attempt 3)', $message);
+        self::assertSame($this->completeXml('<dimension>value</dimension>'), $context['document_xml']);
+
+        [$level, $message, $context] = $this->logs[5];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Received response from Twinfield.', $message);
+        self::assertSame($this->completeXml('<dimension result="1">value</dimension>'), $context['document_xml']);
+    }
+
+    public function testSendDocumentLogsFailures()
+    {
+        $request_document = new \DOMDocument();
+        $request_document->loadXML('<dimension>value</dimension>');
+
+        $this->connection->expects($this->any())
+            ->method("getAuthenticatedClient")
+            ->with(Services::PROCESSXML())
+            ->willReturn($this->client);
+
+        $this->client->expects($this->any())
+            ->method("sendDocument")
+            ->will($this->onConsecutiveCalls(
+                $this->throwException(new \SoapFault('Server', 'Internal server error'))
+            ));
+
+        $this->service->setLogger($this);
+        try {
+            $this->service->sendXmlDocument($request_document);
+        } catch (\PhpTwinfield\Exception $e) {
+        }
+
+        self::assertCount(2, $this->logs);
+
+        [$level, $message, $context] = $this->logs[0];
+        self::assertSame(LogLevel::DEBUG, $level);
+        self::assertSame('Sending request to Twinfield.', $message);
+        self::assertSame($this->completeXml('<dimension>value</dimension>'), $context['document_xml']);
+
+        [$level, $message, $context] = $this->logs[1];
+        self::assertSame(LogLevel::ERROR, $level);
+        self::assertSame("Request to Twinfield failed: Internal server error", $message);
+        self::assertEmpty($context);
     }
 
     /**


### PR DESCRIPTION
I've added logging to the `BaseApiConnector` so that it becomes possible to debug the actual requests and responses send and received from Twinfield.