### PR TITLE
Make sure we can map bank transactions without line ids

### DIFF
--- a/src/ApiConnectors/BankTransactionApiConnector.php
+++ b/src/ApiConnectors/BankTransactionApiConnector.php
@@ -6,6 +6,7 @@ use PhpTwinfield\BankTransaction;
 use PhpTwinfield\DomDocuments\BankTransactionDocument;
 use PhpTwinfield\Exception;
 use PhpTwinfield\Mappers\BankTransactionMapper;
+use PhpTwinfield\Response\IndividualMappedResponse;
 use PhpTwinfield\Response\MappedResponseCollection;
 use PhpTwinfield\Response\Response;
 use Webmozart\Assert\Assert;
@@ -34,7 +35,7 @@ class BankTransactionApiConnector extends BaseApiConnector
 
     /**
      * @param BankTransaction[] $bankTransactions
-     * @return MappedResponseCollection
+     * @return MappedResponseCollection|IndividualMappedResponse[]
      * @throws Exception
      */
     public function sendAll(array $bankTransactions): MappedResponseCollection

--- a/src/Mappers/BankTransactionMapper.php
+++ b/src/Mappers/BankTransactionMapper.php
@@ -149,7 +149,15 @@ class BankTransactionMapper extends BaseMapper
         \DOMElement $lineElement,
         Base $line
     ): void {
-        $line->setId($lineElement->getAttribute("id"));
+        /*
+         * When a bank transaction fails, it isn't created at Twinfield, so it is likely that they haven't generated
+         * any ids for the lines.
+         */
+        $id = $lineElement->getAttribute("id");
+        if (!empty($id)) {
+            $line->setId($id);
+        }
+
         $value = self::getField($lineElement, 'value');
         $line->setValue(Util::parseMoney($value, $bankTransaction->getCurrency()));
         $line->setInvoiceNumber(self::getField($lineElement, "invoicenumber"));

--- a/tests/UnitTests/ApiConnectors/resources/failed-response-without-line-ids.xml
+++ b/tests/UnitTests/ApiConnectors/resources/failed-response-without-line-ids.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<transactions result="0">
+	<transaction destiny="temporary" msgtype="error" msg="Configuratiefout in rekening-courant. Er is geen directe ontvangstregel in administratie MyAdministration (450)." result="0">
+		<header>
+			<code>BNK_CODE_123</code>
+			<office>450</office>
+			<date>20170901</date>
+			<statementnumber>321</statementnumber>
+			<currency>EUR</currency>
+			<startvalue>0.00</startvalue>
+			<closevalue>126.17</closevalue>
+			<origin>import</origin>
+		</header>
+		<lines>
+			<line type="total">
+				<dim1>123456</dim1>
+				<debitcredit>credit</debitcredit>
+				<value>126.17</value>
+			</line>
+			<line type="detail">
+				<dim1>654321</dim1>
+				<debitcredit>credit</debitcredit>
+				<value>126.17</value>
+				<description>description</description>
+				<comment>comment</comment>
+			</line>
+		</lines>
+	</transaction>
+</transactions>


### PR DESCRIPTION
When a bank transaction fails to be created for whatever reason,
Twinfield does not generate an ID for the lines in the bank transaction,
so when mapping the response we should not require them to be set.