### PR TITLE
Thijs/keep line order consistent

### DIFF
--- a/src/BankTransaction.php
+++ b/src/BankTransaction.php
@@ -99,7 +99,7 @@ class BankTransaction implements Transaction
         /*
          * Max is 500 lines. 
          */
-        Assert::lessThanEq(count($this->getLines()), 500);
+        Assert::lessThanEq($this->getLineCount(), 500);
 
         /*
          * Calls the addLine() method on the LinesField trait. Uses an alias in the `use` statement at top of this

--- a/src/BankTransaction.php
+++ b/src/BankTransaction.php
@@ -99,7 +99,7 @@ class BankTransaction implements Transaction
         /*
          * Max is 500 lines. 
          */
-        Assert::lessThanEq($this->getLineCount(), 500);
+        Assert::lessThan($this->getLineCount(), 500);
 
         /*
          * Calls the addLine() method on the LinesField trait. Uses an alias in the `use` statement at top of this

--- a/src/Enums/LineType.php
+++ b/src/Enums/LineType.php
@@ -11,7 +11,7 @@ use MyCLabs\Enum\Enum;
  */
 class LineType extends Enum
 {
-    protected const TOTAL = "total";
-    protected const DETAIL = "detail";
-    protected const VAT = "vat";
+    public const TOTAL = "total";
+    public const DETAIL = "detail";
+    public const VAT = "vat";
 }

--- a/src/Transactions/TransactionFields/LinesField.php
+++ b/src/Transactions/TransactionFields/LinesField.php
@@ -22,6 +22,13 @@ trait LinesField
      */
     abstract public function getLineClassName(): string;
 
+    protected function getLineCount(): int
+    {
+        return $this->getLineCountForType(LineType::TOTAL())
+            + $this->getLineCountForType(LineType::DETAIL())
+            + $this->getLineCountForType(LineType::VAT());
+    }
+
     private function getLineCountForType(LineType $line_type): int
     {
         if (\array_key_exists($line_type->getValue(), $this->lines_per_type)) {

--- a/src/Transactions/TransactionFields/LinesField.php
+++ b/src/Transactions/TransactionFields/LinesField.php
@@ -14,7 +14,11 @@ trait LinesField
     /**
      * @var TransactionLine[][]
      */
-    private $lines_per_type = [];
+    private $lines_per_type = [
+        LineType::TOTAL  => [],
+        LineType::DETAIL => [],
+        LineType::VAT    => [],
+    ];
 
     /**
      * @return string The class name for transaction lines supported by this transaction. Must be an implementation of
@@ -31,11 +35,7 @@ trait LinesField
 
     private function getLineCountForType(LineType $line_type): int
     {
-        if (\array_key_exists($line_type->getValue(), $this->lines_per_type)) {
-            return count($this->lines_per_type[$line_type->getValue()]);
-        }
-
-        return 0;
+        return count($this->lines_per_type[$line_type->getValue()]);
     }
 
     /**
@@ -48,45 +48,26 @@ trait LinesField
          * one or more detail lines and optionally one or more vat lines. Twinfield returns an error when the lines are
          * in an incorrect order.
          */
-        $lines = [];
-
-        foreach ($this->getTotalLines() as $line) {
-            $lines[] = $line;
-        }
-
-        foreach ($this->getDetailLines() as $line) {
-            $lines[] = $line;
-        }
-
-        foreach ($this->getVatLines() as $line) {
-            $lines[] = $line;
-        }
-
-        return $lines;
+        return \array_merge(
+            $this->getTotalLines(),
+            $this->getDetailLines(),
+            $this->getVatLines()
+        );
     }
 
     private function getTotalLines(): array
     {
-        return $this->getLinesOfType(LineType::TOTAL());
-    }
-
-    private function getLinesOfType(LineType $line_type): array
-    {
-        if (\array_key_exists($line_type->getValue(), $this->lines_per_type)) {
-            return $this->lines_per_type[$line_type->getValue()];
-        }
-
-        return [];
+        return $this->lines_per_type[LineType::TOTAL()->getValue()];
     }
 
     private function getDetailLines(): array
     {
-        return $this->getLinesOfType(LineType::DETAIL());
+        return $this->lines_per_type[LineType::DETAIL()->getValue()];
     }
 
     private function getVatLines(): array
     {
-        return $this->getLinesOfType(LineType::VAT());
+        return $this->lines_per_type[LineType::VAT()->getValue()];
     }
 
     /**
@@ -97,21 +78,14 @@ trait LinesField
     {
         Assert::isInstanceOf($line, $this->getLineClassName());
 
-        $this->addLinePerType($line);
+        if ($line->getLineType()->equals(LineType::TOTAL())) {
+            Assert::eq($this->getLineCountForType(LineType::TOTAL()), 0, 'Cannot set a second TOTAL line');
+        }
+
+        $this->lines_per_type[$line->getLineType()->getValue()][] = $line;
         $line->setTransaction($this);
 
         return $this;
-    }
-
-    private function addLinePerType(TransactionLine $line)
-    {
-        $line_type = $line->getLineType()->getValue();
-
-        if (!\array_key_exists($line_type, $this->lines_per_type)) {
-            $this->lines_per_type[$line_type] = [];
-        }
-
-        $this->lines_per_type[$line_type][] = $line;
     }
 
     /**

--- a/tests/UnitTests/BankTransactionUnitTest.php
+++ b/tests/UnitTests/BankTransactionUnitTest.php
@@ -4,8 +4,12 @@ namespace PhpTwinfield\UnitTests;
 
 use Money\Money;
 use PhpTwinfield\BankTransaction;
+use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\Office;
+use PhpTwinfield\Transactions\BankTransactionLine\Base;
 use PhpTwinfield\Transactions\BankTransactionLine\Detail;
+use PhpTwinfield\Transactions\BankTransactionLine\Total;
+use PhpTwinfield\Transactions\TransactionLine;
 
 class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
 {
@@ -29,5 +33,103 @@ class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals("201300003", $reference->getNumber());
         $this->assertEquals("1", $reference->getLineId());
         $this->assertEquals("MEMO", $reference->getCode());
+    }
+
+    public function testGetLineReturnsLinesInSameOrderButAlwaysWithTotalAtTheTop()
+    {
+        $total_line_count = 287;
+
+        $bank_transaction = new BankTransaction();
+
+        for ($i = 1; $i < $total_line_count; $i++) {
+            $this->addDetailLineWithDescription($bank_transaction, (string)$i);
+        }
+
+        $this->addTotalLineWithDescription($bank_transaction, '0');
+
+        self::assertLinesInOrderBasedOnDescription($bank_transaction, $total_line_count);
+    }
+
+    private static function assertLinesInOrderBasedOnDescription(
+        BankTransaction $bank_transaction,
+        int $expected_line_count
+    ) {
+        $i = 0;
+        /** @var Base $line */
+        foreach ($bank_transaction->getLines() as $line) {
+            self::assertSame(
+                $i,
+                (int)$line->getDescription(),
+                'Expected line #' . $i . ', but got line #' . $line->getDescription() .
+                ' of type ' . $line->getLineType()->getValue() . '. Wrong order!'
+            );
+            $i++;
+        }
+
+        self::assertSame($expected_line_count, $i, 'Number of returned lines does not match number of added lines');
+    }
+
+    private function addTotalLineWithDescription(BankTransaction $bankTransaction, string $description): Total
+    {
+        $line = new Total();
+        $line->setDescription($description);
+        $line->setValue(Money::EUR(0));
+
+        $bankTransaction->addLine($line);
+
+        return $line;
+    }
+
+    private function addDetailLineWithDescription(BankTransaction $bankTransaction, string $description): Detail
+    {
+        $line = new Detail();
+        $line->setDescription($description);
+        $line->setValue(Money::EUR(0));
+
+        $bankTransaction->addLine($line);
+
+        return $line;
+    }
+
+    public function testGetLinesReturnsLinesInTheSameOrderAsTheyWereAdded()
+    {
+        $total_line_count = 300;
+
+        $bank_transaction = new BankTransaction();
+
+        $this->addTotalLineWithDescription($bank_transaction, '0');
+
+        for ($i = 1; $i < $total_line_count; $i++) {
+            $this->addDetailLineWithDescription($bank_transaction, (string)$i);
+        }
+
+        self::assertLinesInOrderBasedOnDescription($bank_transaction, $total_line_count);
+    }
+
+    public function testGetLinesReturnsEmptyArrayWhenNoLinesSet()
+    {
+        $bank_transaction = new BankTransaction();
+
+        self::assertCount(0, $bank_transaction->getLines());
+    }
+
+    public function testGetLinesReturnsLinesInSameOrderWhenOnlyDetailsAdded()
+    {
+        $bank_transaction = new BankTransaction();
+
+        $this->addDetailLineWithDescription($bank_transaction, '0');
+        $this->addDetailLineWithDescription($bank_transaction, '1');
+        $this->addDetailLineWithDescription($bank_transaction, '2');
+
+        self::assertLinesInOrderBasedOnDescription($bank_transaction, 3);
+    }
+
+    public function testGetLinesReturnsLinesInSameOrderWhenOnlyTotalLineIsAdded()
+    {
+        $bank_transaction = new BankTransaction();
+
+        $this->addTotalLineWithDescription($bank_transaction, '0');
+
+        self::assertLinesInOrderBasedOnDescription($bank_transaction, 1);
     }
 }

--- a/tests/UnitTests/BankTransactionUnitTest.php
+++ b/tests/UnitTests/BankTransactionUnitTest.php
@@ -134,9 +134,9 @@ class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($bank_transaction->getLines()[0]->getLineType()->equals(LineType::TOTAL()));
     }
 
-    public function testAdding1TotalLineAnd500DetailLinesToABankTransactionWorks()
+    public function testAdding1TotalLineAnd499DetailLinesToABankTransactionWorks()
     {
-        $total_line_count = 501;
+        $total_line_count = 500;
 
         $bank_transaction = new BankTransaction();
 
@@ -145,12 +145,12 @@ class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
             $this->addDetailLineWithDescription($bank_transaction, (string)$i);
         }
 
-        self::assertCount(501, $bank_transaction->getLines());
+        self::assertCount($total_line_count, $bank_transaction->getLines());
     }
 
-    public function testAdding1TotalLineWithMoreThan500DetailLinesToABankTransactionThrows()
+    public function testAdding1TotalLineWith500DetailLinesToABankTransactionThrows()
     {
-        $total_line_count = 502;
+        $total_line_count = 501;
 
         $bank_transaction = new BankTransaction();
 

--- a/tests/UnitTests/BankTransactionUnitTest.php
+++ b/tests/UnitTests/BankTransactionUnitTest.php
@@ -124,13 +124,14 @@ class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
         self::assertLinesInOrderBasedOnDescription($bank_transaction, 3);
     }
 
-    public function testGetLinesReturnsLinesInSameOrderWhenOnlyTotalLineIsAdded()
+    public function testGetLinesReturnsOnlyTotalLineWhenOnlyTotalLineIsAdded()
     {
         $bank_transaction = new BankTransaction();
 
         $this->addTotalLineWithDescription($bank_transaction, '0');
 
-        self::assertLinesInOrderBasedOnDescription($bank_transaction, 1);
+        self::assertCount(1, $bank_transaction->getLines());
+        self::assertTrue($bank_transaction->getLines()[0]->getLineType()->equals(LineType::TOTAL()));
     }
 
     public function testAdding1TotalLineAnd500DetailLinesToABankTransactionWorks()
@@ -159,6 +160,21 @@ class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
 
         for ($i = 1; $i < $total_line_count; $i++) {
             $this->addDetailLineWithDescription($bank_transaction, (string)$i);
+        }
+    }
+
+    public function testAddLineThrowsAndIgnoresWhenAddingASecondTotalLine()
+    {
+        $bank_transaction = new BankTransaction();
+
+        $this->addTotalLineWithDescription($bank_transaction, '0');
+
+        try {
+            $this->addTotalLineWithDescription($bank_transaction, '0');
+
+            self::fail('An exception should have been thrown when adding a second total line');
+        } catch (\InvalidArgumentException $e) {
+            self::assertCount(1, $bank_transaction->getLines());
         }
     }
 }

--- a/tests/UnitTests/BankTransactionUnitTest.php
+++ b/tests/UnitTests/BankTransactionUnitTest.php
@@ -132,4 +132,33 @@ class BankTransactionUnitTest extends \PHPUnit\Framework\TestCase
 
         self::assertLinesInOrderBasedOnDescription($bank_transaction, 1);
     }
+
+    public function testAdding1TotalLineAnd500DetailLinesToABankTransactionWorks()
+    {
+        $total_line_count = 501;
+
+        $bank_transaction = new BankTransaction();
+
+        $this->addTotalLineWithDescription($bank_transaction, '0');
+        for ($i = 1; $i < $total_line_count; $i++) {
+            $this->addDetailLineWithDescription($bank_transaction, (string)$i);
+        }
+
+        self::assertCount(501, $bank_transaction->getLines());
+    }
+
+    public function testAdding1TotalLineWithMoreThan500DetailLinesToABankTransactionThrows()
+    {
+        $total_line_count = 502;
+
+        $bank_transaction = new BankTransaction();
+
+        $this->addTotalLineWithDescription($bank_transaction, '0');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        for ($i = 1; $i < $total_line_count; $i++) {
+            $this->addDetailLineWithDescription($bank_transaction, (string)$i);
+        }
+    }
 }

--- a/tests/UnitTests/JournalTransactionUnitTest.php
+++ b/tests/UnitTests/JournalTransactionUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\UnitTests;
 
+use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\JournalTransaction;
 use PhpTwinfield\JournalTransactionLine;
 use PhpTwinfield\Office;
@@ -16,6 +17,7 @@ class JournalTransactionUnitTest extends \PHPUnit\Framework\TestCase
         $journal->setCode("MEMO");
 
         $line = new JournalTransactionLine();
+        $line->setLineType(LineType::DETAIL());
         $line->setId(1);
 
         $journal->addLine($line);

--- a/tests/UnitTests/PurchaseTransactionsUnitTest.php
+++ b/tests/UnitTests/PurchaseTransactionsUnitTest.php
@@ -48,6 +48,7 @@ class PurchaseTransactionsUnitTest extends TestCase
         $purchase->setCode("INK");
 
         $line = new PurchaseTransactionLine();
+        $line->setLineType(LineType::DETAIL());
         $line->setId(2);
 
         $purchase->addLine($line);

--- a/tests/UnitTests/SalesTransactionLineUnitTest.php
+++ b/tests/UnitTests/SalesTransactionLineUnitTest.php
@@ -52,6 +52,7 @@ class SalesTransactionLineUnitTest extends \PHPUnit\Framework\TestCase
         $purchase->setCode("INK");
 
         $line = new SalesTransactionLine();
+        $line->setLineType(LineType::DETAIL());
         $line->setId(2);
 
         $purchase->addLine($line);

--- a/tests/UnitTests/SalesTransactionUnitTest.php
+++ b/tests/UnitTests/SalesTransactionUnitTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace PhpTwinfield\UnitTests;
+
+use Money\Money;
+use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\SalesTransaction;
+use PhpTwinfield\SalesTransactionLine;
+
+class SalesTransactionUnitTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetLinesReturnsLinesInSameOrderWhenAlreadyInsertedInTheRightOrder()
+    {
+        $sales_transaction = new SalesTransaction();
+
+        $this->addLineWithDescription($sales_transaction, LineType::TOTAL(), '0');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '1');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '2');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '3');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '4');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '5');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '6');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '7');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '8');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '9');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '10');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '11');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '12');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '13');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '14');
+
+        self::assertLinesInOrderBasedOnDescription($sales_transaction, 15);
+    }
+
+    public function testGetLinesReturnsLinesInSameOrderWhenInsertionOrderiExtremelyMixed()
+    {
+        $sales_transaction = new SalesTransaction();
+
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '9');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '1');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '10');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '2');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '11');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '3');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '12');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '4');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '13');
+        $this->addLineWithDescription($sales_transaction, LineType::TOTAL(), '0');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '5');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '6');
+        $this->addLineWithDescription($sales_transaction, LineType::VAT(), '14');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '7');
+        $this->addLineWithDescription($sales_transaction, LineType::DETAIL(), '8');
+
+        self::assertLinesInOrderBasedOnDescription($sales_transaction, 15);
+    }
+
+    private function addLineWithDescription(
+        SalesTransaction $salesTransaction,
+        LineType $line_type,
+        string $description
+    ): SalesTransactionLine {
+        $line = new SalesTransactionLine();
+        $line->setLineType($line_type);
+        $line->setDescription($description);
+        $line->setValue(Money::EUR(0));
+
+        $salesTransaction->addLine($line);
+
+        return $line;
+    }
+
+    private static function assertLinesInOrderBasedOnDescription(
+        SalesTransaction $sales_transaction,
+        int $expected_line_count
+    ) {
+        $i = 0;
+        /** @var SalesTransactionLine $line */
+        foreach ($sales_transaction->getLines() as $line) {
+            self::assertSame(
+                $i,
+                (int)$line->getDescription(),
+                'Expected line #' . $i . ', but got line #' . $line->getDescription() .
+                ' of type ' . $line->getLineType()->getValue() . '. Wrong order!'
+            );
+            $i++;
+        }
+
+        self::assertSame($expected_line_count, $i, 'Number of returned lines does not match number of added lines');
+    }
+}


### PR DESCRIPTION
* Lines that are added to a `BankTranasction` (or any other object using the `LineField` trait) will now be retrieved in the same order as they were added. Note that they will still be ordered by line type as the primary order (TOTAL, then DETAIL, then VAT).