### PR TITLE
Add support to list all offices when using AccessToken based authentication

### DIFF
--- a/src/Request/Catalog/Office.php
+++ b/src/Request/Catalog/Office.php
@@ -21,6 +21,7 @@ class Office extends Catalog
      */
     public function __construct()
     {
+        parent::__construct();
         $this->add('type', 'offices');
     }
 }

--- a/src/Secure/OpenIdConnectAuthentication.php
+++ b/src/Secure/OpenIdConnectAuthentication.php
@@ -105,8 +105,11 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
     protected function validateToken(): array
     {
         $validationUrl    = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation?token=";
+        $validationResult = false;
         try {
-            $validationResult = @file_get_contents($validationUrl . urlencode($this->accessToken));
+            if ($this->accessToken !== null) {
+                $validationResult = @file_get_contents($validationUrl . urlencode($this->accessToken));
+            }
         } catch (\Exception $e) {
             throw new OAuthException("Could not validate access token: {$e->getMessage()}");
         }

--- a/src/Secure/OpenIdConnectAuthentication.php
+++ b/src/Secure/OpenIdConnectAuthentication.php
@@ -44,8 +44,11 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
      * The office code that is part of the Office object that is passed here will be
      * the default office code used during requests. If an office code is included in
      * the SOAP request body, this will always take precedence over this default.
+     *
+     * Please note that when you leave the office code blank you will have to supply
+     * it with every request.
      */
-    public function __construct(OAuthProvider $provider, string $refreshToken, Office $office)
+    public function __construct(OAuthProvider $provider, string $refreshToken, ?Office $office)
     {
         $this->provider     = $provider;
         $this->refreshToken = $refreshToken;
@@ -59,13 +62,20 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
 
     protected function getSoapHeaders()
     {
+        $headers = [
+            "AccessToken"   =>  $this->accessToken,
+        ];
+
+        // Watch out. When you don't supply an Office and do an authenticated call you will get an
+        // exception from Twinfield saying 'Toegang geweigerd. Company ontbreekt in request header.'
+        if ($this->office !== null) {
+            $headers["CompanyCode"] = $this->office->getCode();
+        }
+
         return new \SoapHeader(
             'http://www.twinfield.com/',
             'Header',
-            [
-                'AccessToken' => $this->accessToken,
-                'CompanyCode' => $this->office->getCode()
-            ]
+            $headers
         );
     }
 


### PR DESCRIPTION
This pull request adds support to list all offices available to the current user authenticated via OAuth / OpenID. 

**Use case:**
We have a case where the customer wants to choose an office without giving a starting point.

**Solves:**
- 400 Bad Request when calling validateToken without an access token.
- Allow to instantiate OpenIdConnectAuthentication without an office present.

**TODO**
- Integration test: at the moment we don't have time to contribute an integration test to see what it does on all the other classes. We plan to do this later this week.