### PR TITLE
removeAddress() method in the Customer class.

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -338,6 +338,16 @@ class Customer
         return $this;
     }
 
+    public function removeAddress($index)
+    {
+        if (array_key_exists($index, $this->addresses)) {
+            unset($this->addresses[$index]);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public function getBanks()
     {
         return $this->banks;


### PR DESCRIPTION
I would like to use the removeAddress() method in the Customer class but when I try to use it, it give me an error. After searching in the method I noticed that the 'addresses' property in this method was misspelled two times (two different ways).

I've changed the name of the properties and it now works fine for me.