### PR TITLE
Remove duedate from SalesTransaction.

### DIFF
--- a/src/SalesTransaction.php
+++ b/src/SalesTransaction.php
@@ -12,7 +12,7 @@ use PhpTwinfield\Transactions\TransactionLineFields\ThreeDimFields;
  */
 class SalesTransaction extends BaseTransaction
 {
-    use DueDateField;
+    // use DueDateField;
     use InvoiceNumberField;
     use PaymentReferenceField;
     use ThreeDimFields;


### PR DESCRIPTION
Removes the duedate from sales transactions, since the Twinfield API doesn't allow the duedate in the header anymore (`Vervaldatum is niet toegestaan in de koptekst.`).

Code to reproduce this issue

```php
$transaction = new SalesTransaction;
$transaction->setDestiny(Destiny::TEMPORARY())
    ->setCurrency($invoice->getCurrency())
    ->setDateFromString($invoice->getInvoiceDate()->format("Ymd"))
    ->setPeriod($invoice->getInvoiceDate()->format("Y/m"))
    ->setDueDateFromString($invoice->getDueDate()->format("Ymd"))
```

Will yield the following error:
```
Argument 1 passed to PhpTwinfield\SalesTransaction::setDueDateFromString() must be of the type string, null given, called in project/vendor/php-twinfield/twinfield/src/Mappers/TransactionMapper.php on line 107
```
Removing the duedate from `SalesTransaction` will fix this issue. Code not removed from the `TransactionMapper` since it might be used by other Transactions.