### PR TITLE
get/setDueDate in Invoice + TransactionMapper fails when reading/mapping certain transactions 

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -38,6 +38,7 @@ class Invoice
     private $status;
     private $currency;
     private $invoiceDate;
+    private $dueDate;
     private $performanceDate;
     private $paymentMethod;
     private $bank;
@@ -143,6 +144,17 @@ class Invoice
     public function setInvoiceDate($invoiceDate)
     {
         $this->invoiceDate = $invoiceDate;
+        return $this;
+    }
+	
+    public function getDueDate()
+    {
+	return $this->dueDate;
+    }
+	
+    public function setDueDate($dueDate)
+    {
+        $this->dueDate = $dueDate;
         return $this;
     }
 

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -21,7 +21,7 @@ class InvoiceMapper extends BaseMapper
             'currency'             => 'setCurrency',
             'period'               => 'setPeriod',
             'invoicedate'          => 'setInvoiceDate',
-            'duedate'              => 'setDueDateFromString',
+            'duedate'              => 'setDueDate',
             'performancedate'      => 'setPerformanceDate',
             'paymentmethod'        => 'setPaymentMethod',
             'bank'                 => 'setBank',

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -85,6 +85,7 @@ class InvoiceMapper extends BaseMapper
             'valueinc'               => 'setValueInc',
             'unitspriceexcl'         => 'setUnitsPriceExcl',
             'unitspriceinc'          => 'setUnitsPriceInc',
+            'vatcode'                => 'setVatCode',
             'freetext1'              => 'setFreeText1',
             'freetext2'              => 'setFreeText2',
             'freetext3'              => 'setFreeText3',

--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -140,6 +140,10 @@ class TransactionMapper
             /** @var BaseTransactionLine $transactionLine */
             $transactionLine = new $transactionLineClassName();
             $lineType        = $lineElement->getAttribute('type');
+            
+            if ($lineType == null) {
+				continue;
+			}
 
             $transactionLine
                 ->setLineType(new LineType($lineType))

--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -142,8 +142,8 @@ class TransactionMapper
             $lineType        = $lineElement->getAttribute('type');
             
             if ($lineType == null) {
-				continue;
-			}
+                continue;
+            }
 
             $transactionLine
                 ->setLineType(new LineType($lineType))


### PR DESCRIPTION
1: get/setDueDate is missing from the Invoice class

2: When trying to read a transaction using the TransactionApiConnector->get function, it fails when trying to map lines from a match set in addition to mapping the regular lines from the transaction.

Consider the following XML which is returned when requesting a SalesTransaction:

```xml
<?xml version="1.0"?>
<transaction location="final" result="1">
<header>
<office name="SOMEOFFICENAME" shortname="SOMESHORTOFFICENAME">SOMEOFFICECODE</office>
<code name="INVOICE" shortname="INVOICE">INVOICECODE</code>
<number>201900001</number>
<period>2019/01</period>
<currency name="Euro" shortname="Euro">EUR</currency>
<regime>Generic</regime>
<date>20190101</date>
<origin>invoice</origin>
<originreference/>
<modificationdate>20190101170000</modificationdate>
<user name="SOMEUSERNAME" shortname="SOMESHORTUSERNAME">SOMEUSERCODE</user>
<inputdate>20190101170000</inputdate>
<duedate>20190115</duedate>
<invoicenumber>201900001</invoicenumber>
<freetext3/>
</header>
<lines>
<line type="total" id="1">
<dim1 name="SOMEDEBTORS" shortname="" dimensiontype="BAS">SOMEDEBTORSCODE</dim1>
<dim2 name="SOMECLIENTNAME" shortname="" dimensiontype="DEB">SOMECLIENTCODE</dim2>
<debitcredit>debit</debitcredit>
<basevalue>77.50</basevalue>
<rate>1</rate>
<value>77.50</value>
<reprate>1</reprate>
<repvalue>77.50</repvalue>
<description>Total</description>
<vatbasetotal>6.40</vatbasetotal>
<vattotal>6.40</vattotal>
<matchstatus>matched</matchstatus>
<matchlevel>2</matchlevel>
<relation>2</relation>
<matchdate>20190325</matchdate>
<matches>
<set status="final">
<matchdate>20190325</matchdate>
<lines>
<line>
<code>SOMEDIMENSIONCODE</code>
<number>201900002</number>
<line>2</line>
<method>payment</method>
<matchvalue>-77.50</matchvalue>
</line></lines>
<matchvalue>77.50</matchvalue>
</set>
</matches>
</line>
<line type="detail" id="2">
<dim1 VatCode="VL" name="SOMEARTICLEDESCRIPTION" shortname="" dimensiontype="PNL">SOMEARTICLECODE</dim1>
<dim2 name="SOMEDIMENSION2" shortname="" dimensiontype="KPL">SOMEDIMENSIONCODE2</dim2>
<debitcredit>credit</debitcredit>
<basevalue>64.22</basevalue>
<rate>1</rate>
<value>64.22</value>
<reprate>1</reprate>
<repvalue>64.22</repvalue>
<description>SOMEARTICLEDESCRIPTION</description>
<vatcode name="9%" shortname="9%" type="sales">VL</vatcode>
<vatbasevalue>5.78</vatbasevalue>
<vatvalue>5.78</vatvalue>
<matchstatus>notmatchable</matchstatus>
</line>
<line type="detail" id="3">
<dim1 VatCode="VL" name="SOMEARTICLEDESCRIPTION2" shortname="" dimensiontype="PNL">SOMEARTICLECODE2</dim1>
<dim2 name="SOMEDIMENSION2" shortname="" dimensiontype="KPL">SOMEDIMENSIONCODE2</dim2>
<debitcredit>credit</debitcredit>
<basevalue>6.88</basevalue>
<rate>1</rate>
<value>6.88</value>
<reprate>1</reprate>
<repvalue>6.88</repvalue>
<description>SOMEARTICLEDESCRIPTION2</description>
<vatcode name="9%" shortname="9%" type="sales">VL</vatcode><vatbasevalue>0.62</vatbasevalue>
<vatvalue>0.62</vatvalue>
<matchstatus>notmatchable</matchstatus>
</line>
<line type="vat" id="4">
<dim1 name="SOMEVATDESCRIPTION" shortname="" dimensiontype="BAS">SOMEVATCODE</dim1>
<debitcredit>credit</debitcredit>
<basevalue>6.40</basevalue>
<rate>1</rate>
<value>6.40</value>
<reprate>1</reprate>
<repvalue>6.40</repvalue>
<description>Btw</description>
<vatbaseturnover>71.10</vatbaseturnover>
<vatturnover>71.10</vatturnover>
<vatcode name="9%" shortname="9%" type="sales">VL</vatcode>
<vatbasevalue>0.00</vatbasevalue>
<vatvalue>0.00</vatvalue>
<baseline>1</baseline>
<matchstatus>notmatchable</matchstatus>
</line>
</lines>
</transaction>
```

Line 137 in TransactionMapper.php matches not only the totals, 2 detail and vat lines but also the line inside the match set.
```php
foreach ($transactionElement->getElementsByTagName('line') as $lineElement) {
```

TransactionMapper subsequently fails on line 142/145 because the line(s) in the match set don't have a type attribute.
```php
$lineType        = $lineElement->getAttribute('type');

$transactionLine
->setLineType(new LineType($lineType))
```
My pull request skips lines lacking a type attribute