### PR TITLE
Add possibility to connect using known/stored OpenID access token and cluster

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Go to the [Twinfield web site](https://www.twinfield.nl/openid-connect-request/)
 
 ##### Grant Authorisation and retrieve intitial Access Token
 On loading a page containing the following code the user will be redirected to the Twinfield Login page.
-After succesfull login and optionally consent (see above) the user will be redirected back to the page and which point the Access Token and Refresh Token are retrieved.
+After succesfull login and optionally consent (see above) the user will be redirected back to the page at which point the Access Token and Refresh Token can be retrieved.
 
 For more information, please refer to: https://github.com/thephpleague/oauth2-client#usage
 

--- a/src/Secure/OpenIdConnectAuthentication.php
+++ b/src/Secure/OpenIdConnectAuthentication.php
@@ -48,11 +48,13 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
      * Please note that for most calls an office is mandatory. If you do not supply it
      * you have to pass it with every request, or call setOffice.
      */
-    public function __construct(OAuthProvider $provider, string $refreshToken, ?Office $office)
+    public function __construct(OAuthProvider $provider, string $refreshToken, ?Office $office, string $accessToken = null, string $cluster = null)
     {
         $this->provider     = $provider;
+        $this->accessToken  = $accessToken;
         $this->refreshToken = $refreshToken;
         $this->office       = $office;
+        $this->cluster      = $cluster;
     }
 
     public function setOffice(?Office $office)
@@ -95,8 +97,10 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
             $this->refreshToken();
         }
 
-        $validationResult = $this->validateToken();
-        $this->cluster = $validationResult["twf.clusterUrl"];
+        if ($this->cluster === null) {
+            $validationResult = $this->validateToken();
+            $this->cluster = $validationResult["twf.clusterUrl"];
+        }
     }
 
     /**


### PR DESCRIPTION
Adds the possibility to optionally pass a known access token and cluster to OpenIdConnectAuthentication.
Designed to be a non-breaking change. 

In my use case a cron job is running every 45 minutes to refresh my access token and cluster, which are then stored. When a connection to the API is required the tokens, expiry time and cluster are retrieved and used to connect to Twinfield. 

Connection takes about 2 seconds less this way and lessens the total amount of calls to Twinfield when connecting more than 20-30 times/day.

Example:

Cron Job running every 45 minutes:
```php

$refreshToken = retrieveRefreshTokenFromStore();

$provider    = new OAuthProvider([
    'clientId'     => 'someClientId',
    'clientSecret' => 'someClientSecret',
    'redirectUri'  => 'https://example.org/'
]);

$accessToken = $provider->getAccessToken('refresh_token', [
    'refresh_token' => $refreshToken
]);

$validationUrl    = "https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation?token=";
$validationResult = @file_get_contents($validationUrl . urlencode($accessToken->getToken()));

if ($validationResult !== false) {
    $resultDecoded                    = \json_decode($validationResult, true);

    $tokenStorage                     = array();
    $tokenStorage['access_token']     = $accessToken->getToken();
    $tokenStorage['access_expiry']    = $accessToken->getExpires();
    $tokenStorage['access_cluster']   = $resultDecoded["twf.clusterUrl"];

    SaveAccessTokenToStore($tokenStorage);
}
```

Connection:
```php

$tokenStorage = retrieveAccessTokenFromStore();
$refreshToken = retrieveRefreshTokenFromStore();

$provider    = new OAuthProvider([
    'clientId'     => 'someClientId',
    'clientSecret' => 'someClientSecret',
    'redirectUri'  => 'https://example.org/'
]);

$office = \PhpTwinfield\Office::fromCode("someOfficeCode");

if ($tokenStorage['access_expiry'] > time()) {
    $connection  = new \PhpTwinfield\Secure\OpenIdConnectAuthentication($provider, $refreshToken, $office, $tokenStorage['access_token'], $tokenStorage['access_cluster']);
} else {
    $connection  = new \PhpTwinfield\Secure\OpenIdConnectAuthentication($provider, $refreshToken, $office)
}
```