### PR TITLE
Extend Invoice resource

### DIFF
--- a/src/DomDocuments/InvoicesDocument.php
+++ b/src/DomDocuments/InvoicesDocument.php
@@ -24,10 +24,10 @@ class InvoicesDocument extends BaseDocument
     /**
      * Turns a passed Invoice class into the required markup for interacting
      * with Twinfield.
-     * 
+     *
      * This method doesn't return anything, instead just adds the invoice
      * to this DOMDocument instance for submission usage.
-     * 
+     *
      * @access public
      * @param Invoice $invoice
      * @return void | [Adds to this instance]
@@ -40,7 +40,7 @@ class InvoicesDocument extends BaseDocument
         // Makes a child header element
         $headerElement = $this->createElement('header');
         $invoiceElement->appendChild($headerElement);
-        
+
         // Set customer element
         $customer = $invoice->getCustomer();
 
@@ -66,20 +66,20 @@ class InvoicesDocument extends BaseDocument
             'headertext'           => 'getHeaderText',
             'footertext'           => 'getFooterText'
         );
-        
+
         // Go through each element and use the assigned method
         foreach ($headerTags as $tag => $method) {
 
             $value = $this->getValueFromCallback([$invoice, $method]);
-    
+
             if(null !== $value) {
                 // Make text node for method value
                 $node = $this->createTextNode($value);
-    
+
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
                 $element->appendChild($node);
-    
+
                 // Add the full element
                 $headerElement->appendChild($element);
             }
@@ -88,7 +88,7 @@ class InvoicesDocument extends BaseDocument
         // Add orders
         $linesElement = $this->createElement('lines');
         $invoiceElement->appendChild($linesElement);
-        
+
         // Elements and their associated methods for lines
         $lineTags = array(
             'quantity'        => 'getQuantity',
@@ -96,6 +96,7 @@ class InvoicesDocument extends BaseDocument
             'subarticle'      => 'getSubArticle',
             'description'     => 'getDescription',
             'unitspriceexcl'  => 'getUnitsPriceExcl',
+            'unitspriceinc'  => 'getUnitsPriceInc',
             'units'           => 'getUnits',
             'vatcode'         => 'getVatCode',
             'freetext1'       => 'getFreeText1',
@@ -116,7 +117,7 @@ class InvoicesDocument extends BaseDocument
 
             // Go through each element and use the assigned method
             foreach ($lineTags as $tag => $method) {
-                
+
                 // Make text node for method value
                 $node = $this->createTextNode($this->getValueFromCallback([$line, $method]));
 

--- a/src/DomDocuments/InvoicesDocument.php
+++ b/src/DomDocuments/InvoicesDocument.php
@@ -96,7 +96,7 @@ class InvoicesDocument extends BaseDocument
             'subarticle'      => 'getSubArticle',
             'description'     => 'getDescription',
             'unitspriceexcl'  => 'getUnitsPriceExcl',
-            'unitspriceinc'  => 'getUnitsPriceInc',
+            'unitspriceinc'   => 'getUnitsPriceInc',
             'units'           => 'getUnits',
             'vatcode'         => 'getVatCode',
             'freetext1'       => 'getFreeText1',

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -24,20 +24,22 @@ use PhpTwinfield\Transactions\TransactionLineFields\PeriodField;
  *
  * @see https://c3.twinfield.com/webservices/documentation/#/ApiReference/SalesInvoices
  * @todo Add documentation and typehints to all properties.
- * @todo Add support for VatLines.
  */
-class Invoice
+class Invoice extends BaseObject
 {
     use PeriodField;
-    use DueDateField;
     use OfficeField;
 
     private $customer;
+    private $customerName;
+    private $debitCredit;
+    private $invoiceAmount;
     private $invoiceType;
     private $invoiceNumber;
     private $status;
     private $currency;
     private $invoiceDate;
+    private $dueDate;
     private $performanceDate;
     private $paymentMethod;
     private $bank;
@@ -69,6 +71,25 @@ class Invoice
         return $this->lines;
     }
 
+	/**
+     * @var InvoiceVatLine[]
+     */
+    private $vatlines = [];
+
+    public function addVatLine(InvoiceVatLine $vatline)
+    {
+        $this->vatlines[] = $vatline;
+        return $this;
+    }
+
+    /**
+     * @return InvoiceVatLine[]
+     */
+    public function getVatLines(): array
+    {
+        return $this->vatlines;
+    }
+
     public function getCustomer(): Customer
     {
         return $this->customer;
@@ -77,6 +98,28 @@ class Invoice
     public function setCustomer(Customer $customer)
     {
         $this->customer = $customer;
+        return $this;
+    }
+
+    public function getCustomerName()
+    {
+        return $this->customerName;
+    }
+
+    public function setCustomerName($customerName)
+    {
+        $this->customerName = $customerName;
+        return $this;
+    }
+
+    public function getDebitCredit()
+    {
+        return $this->debitCredit;
+    }
+
+    public function setDebitCredit($debitCredit)
+    {
+        $this->debitCredit = $debitCredit;
         return $this;
     }
 
@@ -89,6 +132,17 @@ class Invoice
     public function getTotals(): InvoiceTotals
     {
         return $this->totals;
+    }
+
+    public function getInvoiceAmount()
+    {
+        return $this->invoiceAmount;
+    }
+
+    public function setInvoiceAmount($invoiceAmount)
+    {
+        $this->invoiceAmount = $invoiceAmount;
+        return $this;
     }
 
     public function getInvoiceType()
@@ -143,6 +197,17 @@ class Invoice
     public function setInvoiceDate($invoiceDate)
     {
         $this->invoiceDate = $invoiceDate;
+        return $this;
+    }
+
+    public function getDueDate()
+    {
+        return $this->dueDate;
+    }
+
+    public function setDueDate($dueDate)
+    {
+        $this->dueDate = $dueDate;
         return $this;
     }
 

--- a/src/InvoiceVatLine.php
+++ b/src/InvoiceVatLine.php
@@ -1,0 +1,55 @@
+<?php
+namespace PhpTwinfield;
+
+use PhpTwinfield\Enums\PerformanceType;
+use PhpTwinfield\Transactions\TransactionLineFields\VatCodeField;
+
+/**
+ * @see https://c3.twinfield.com/webservices/documentation/#/ApiReference/SalesInvoices
+ * @todo Add documentation and typehints to all properties.
+ */
+class InvoiceVatLine
+{
+    use VatCodeField;
+
+    private $vatValue;
+    private $performanceDate;
+
+    /**
+     * @var PerformanceType|null Mandatory in case of an ICT VAT code.
+     */
+    private $performanceType;
+
+    public function getVatValue()
+    {
+        return $this->vatValue;
+    }
+
+    public function setVatValue($vatValue)
+    {
+        $this->vatValue = $vatValue;
+        return $this;
+    }
+
+    public function getPerformanceDate()
+    {
+        return $this->performanceDate;
+    }
+
+    public function setPerformanceDate($performanceDate)
+    {
+        $this->performanceDate = $performanceDate;
+        return $this;
+    }
+
+    public function getPerformanceType(): ?PerformanceType
+    {
+        return $this->performanceType;
+    }
+
+    public function setPerformanceType(?PerformanceType $performanceType): self
+    {
+        $this->performanceType = $performanceType;
+        return $this;
+    }
+}

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -108,10 +108,10 @@ class InvoiceMapper extends BaseMapper
 
             // Loop through each returned lines for the invoice
             foreach ($linesDOM->childNodes as $lineDOM) {
-                if( $lineDOM->nodeType !== 1 ) {
+                if ($lineDOM->nodeType !== 1) {
                     continue;
                 }
-                
+
                 $invoiceLine = new InvoiceLine();
                 $invoiceLine->setID($lineDOM->getAttribute('id'));
 
@@ -143,10 +143,10 @@ class InvoiceMapper extends BaseMapper
 
             // Loop through each returned lines for the invoice
             foreach ($vatlinesDOM->childNodes as $vatlineDOM) {
-                if( $vatlineDOM->nodeType !== 1 ) {
+                if ($vatlineDOM->nodeType !== 1) {
                     continue;
                 }
-                
+
                 $invoiceVatLine = new InvoiceVatLine();
 
                 foreach ($vatlineTags as $tag => $method) {

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -108,7 +108,10 @@ class InvoiceMapper extends BaseMapper
 
             // Loop through each returned lines for the invoice
             foreach ($linesDOM->childNodes as $lineDOM) {
-
+                if( $lineDOM->nodeType !== 1 ) {
+                    continue;
+                }
+                
                 $invoiceLine = new InvoiceLine();
                 $invoiceLine->setID($lineDOM->getAttribute('id'));
 
@@ -140,6 +143,10 @@ class InvoiceMapper extends BaseMapper
 
             // Loop through each returned lines for the invoice
             foreach ($vatlinesDOM->childNodes as $vatlineDOM) {
+                if( $vatlineDOM->nodeType !== 1 ) {
+                    continue;
+                }
+                
                 $invoiceVatLine = new InvoiceVatLine();
 
                 foreach ($vatlineTags as $tag => $method) {

--- a/src/Request/Read/Invoice.php
+++ b/src/Request/Read/Invoice.php
@@ -2,7 +2,7 @@
 namespace PhpTwinfield\Request\Read;
 
 /**
- * Used to request a specific invoice from a certain
+ * Used to request a specific Invoice from a certain
  * code, number and office.
  * 
  * @package PhpTwinfield


### PR DESCRIPTION
- Adds listAll() function to Invoices
- Adds results/messages to Invoices through BaseObject
- Adds VAT lines
- Adds UnitsPriceInc to Sales invoice lines (for Invoice types that include VAT)
- Adds customerName, debitCredit and invoiceAmount variables which are returned when using listAll()
- Changes looping through Sales invoice lines from:
```php
$responseDOM->getElementsByTagName('line')
```
To:

```php
$linesDOM->childNodes
``` 

- Some formatting/order changes