### PR TITLE
Prevent error when no valid date is returned by Twinfield

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -60,8 +60,12 @@ final class Util
      * @return \DateTimeImmutable
      * @throws Exception
      */
-    public static function parseDateTime(string $dateString)
+    public static function parseDateTime(string $dateString): ?string
     {
+        if($dateString === '') {
+          return null;
+        }
+      
         $date = \DateTimeImmutable::createFromFormat("YmdHis", $dateString);
 
         if (false === $date) {


### PR DESCRIPTION
Twinfield returns an empty string when there is no date in a column of the type datetime. When trying to convert this to a date object an error is triggered. This patch prevents this and returns NULL instead.