### PR TITLE
Reset login when resetting webservice connection

### DIFF
--- a/src/Secure/WebservicesAuthentication.php
+++ b/src/Secure/WebservicesAuthentication.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\Secure;
 
+use PhpTwinfield\Enums\Services;
 use PhpTwinfield\Exception;
 use PhpTwinfield\Services\BaseService;
 
@@ -120,5 +121,19 @@ class WebservicesAuthentication extends AuthenticatedConnection
     protected function getCluster(): string
     {
         return $this->cluster;
+    }
+
+    public function resetClient(Services $service): void
+    {
+        $this->sessionID = NULL;
+
+        parent::resetClient($service);
+    }
+
+    protected function resetAllClients(): void
+    {
+        $this->sessionID = NULL;
+
+        parent::resetAllClients();
     }
 }


### PR DESCRIPTION
When using the webservice authenticator in a queue runner I often receive the error "Your logon credentials are not valid anymore. Try to log on again.". There is a catch in BaseApiConnector::sendXmlDocument which retries the request with a fresh connection, but this fresh connection doesn't log on again. This means the error keeps happening.

I added the resetClient and resetAllClients methods to the WebservicesAuthentication class to reset the sessionID before resetting the connection resulting in a fresh login.