### PR TITLE
Allow reuse of an access token

### DIFF
--- a/src/Secure/OpenIdConnectAuthentication.php
+++ b/src/Secure/OpenIdConnectAuthentication.php
@@ -48,8 +48,9 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
      * Please note that for most calls an office is mandatory. If you do not supply it
      * you have to pass it with every request, or call setOffice.
      */
-    public function __construct(OAuthProvider $provider, string $refreshToken, ?Office $office)
+    public function __construct(OAuthProvider $provider, string $refreshToken, ?Office $office, string $accessToken = null)
     {
+        $this->accessToken  = $accessToken;
         $this->provider     = $provider;
         $this->refreshToken = $refreshToken;
         $this->office       = $office;
@@ -59,6 +60,16 @@ class OpenIdConnectAuthentication extends AuthenticatedConnection
     {
         $this->resetAllClients();
         $this->office = $office;
+    }
+
+    /**
+     * Get the access token.
+     *
+     * @return string|null
+     */
+    public function getAccessToken(): ?string
+    {
+        return $this->accessToken;
     }
 
     protected function getCluster(): ?string


### PR DESCRIPTION
Right now the OpenIdConnectAuthentication always retrieves a fresh access token from Twinfield.

This tiny PR allows implementors of this library to manage access tokens, this means an application could cache and reuse a token (resulting in less requests made to Twinfield and thus faster response times).

I added the access token as an optional last parameter so there are no breaking changes.