### PR TITLE
Add check for missing article line ID attribute

### DIFF
--- a/src/Mappers/ArticleMapper.php
+++ b/src/Mappers/ArticleMapper.php
@@ -7,14 +7,14 @@ use PhpTwinfield\Response\Response;
 
 /**
  * Maps a response DOMDocument to the corresponding entity.
- * 
+ *
  * @package PhpTwinfield
  * @subpackage Mapper
  * @author Willem van de Sande <W.vandeSande@MailCoupon.nl>
  */
 class ArticleMapper extends BaseMapper
 {
-    
+
     /**
      * Maps a Response object to a clean Article entity.
      *
@@ -84,7 +84,13 @@ class ArticleMapper extends BaseMapper
                 $articleLine = new ArticleLine();
 
                 // Set the attributes ( id,status,inuse)
-                $articleLine->setID($lineDOM->getAttribute('id'))
+                $id = $lineDOM->getAttribute('id');
+
+                if (empty($id)) {
+                    $id = $lineDOM->getElementsByTagName('subcode')->item(0)->textContent;
+                }
+
+                $articleLine->setID($id)
                     ->setStatus($lineDOM->getAttribute('status'))
                     ->setInUse($lineDOM->getAttribute('inuse'));
 


### PR DESCRIPTION
In some cases article lines (subarticles) don't have an ID attribute. In that case, during mapping, the latest line will always overwrite the previous one and you'll end up with an article with just one line. See #165.

This PR introduces a check for the existence of the ID attribute and will fall back to the line's subcode if it doesn't exist.