### PR TITLE
Add like browse column operator

### DIFF
--- a/src/Enums/BrowseColumnOperator.php
+++ b/src/Enums/BrowseColumnOperator.php
@@ -8,10 +8,12 @@ use MyCLabs\Enum\Enum;
  * @method static BrowseColumnOperator NONE()
  * @method static BrowseColumnOperator EQUAL()
  * @method static BrowseColumnOperator BETWEEN()
+ * @method static BrowseColumnOperator LIKE()
  */
 class BrowseColumnOperator extends Enum
 {
     protected const NONE = 'none';
     protected const EQUAL = 'equal';
     protected const BETWEEN = 'between';
+    protected const LIKE = 'like';
 }


### PR DESCRIPTION
Twinfield seems to return this operator when querying the browse definition for `130_2` (Customers v2)

Code to reproduce:

```php
$connector = new BrowseDataApiConnector(...);
$connector->->getBrowseDefinition('130_2');
```