### PR TITLE
Allow office name, country code and code getters and setters to handle null

### DIFF
--- a/src/Office.php
+++ b/src/Office.php
@@ -5,17 +5,17 @@ namespace PhpTwinfield;
 class Office
 {
     /**
-     * @var string The code of the office.
+     * @var string|null The code of the office.
      */
     private $code;
 
     /**
-     * @var string The code of the country of the office.
+     * @var string|null The code of the country of the office.
      */
     private $countryCode;
 
     /**
-     * @var string The name of the office.
+     * @var string|null The name of the office.
      */
     private $name;
 
@@ -26,32 +26,32 @@ class Office
         return $instance;
     }
 
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->code;
     }
 
-    public function setCode(string $code): void
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }
 
-    public function getCountryCode(): string
+    public function getCountryCode(): ?string
     {
         return $this->countryCode;
     }
 
-    public function setCountryCode(string $countryCode): void
+    public function setCountryCode(?string $countryCode): void
     {
         $this->countryCode = $countryCode;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName(string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }


### PR DESCRIPTION
Currently the getters and setters on offices require a string, this causes a fatal error when calling a getter while the underlying property is null:

For example:

```php
$office = new Office();
$office->getCode();
# This will cause a fatal error
```

Another solution to this problem would be making the constructor protected, because then the class would only be created via the `fromCode` method, but as this is a breaking change I didn't opt for this.

I also made the setters allow nullable arguments, for convience sake, this shouldn't be a problem since all of the underlying properties can already be null.

Note that, in case of someone extending the Office class and overwriting the existing methods, this PR would be breaking for them (because the return and argument types are changed).