### PR TITLE
Allow dates from Browse data to be null

### DIFF
--- a/src/Mappers/BrowseDataMapper.php
+++ b/src/Mappers/BrowseDataMapper.php
@@ -97,9 +97,9 @@ class BrowseDataMapper extends BaseMapper
             case 'Value':
                 return floatval($value);
             case 'Date':
-                return $value !== '' ?  Util::parseDate($value) : null;
+                return Util::parseDate($value);
             case 'Datetime':
-                return $value !== '' ? Util::parseDateTime($value) : null;
+                return Util::parseDateTime($value);
             default:
                 return $value;
         }

--- a/src/Mappers/BrowseDataMapper.php
+++ b/src/Mappers/BrowseDataMapper.php
@@ -97,9 +97,9 @@ class BrowseDataMapper extends BaseMapper
             case 'Value':
                 return floatval($value);
             case 'Date':
-                return Util::parseDate($value);
+                return $value !== '' ?  Util::parseDate($value) : null;
             case 'Datetime':
-                return Util::parseDateTime($value);
+                return $value !== '' ? Util::parseDateTime($value) : null;
             default:
                 return $value;
         }

--- a/src/Util.php
+++ b/src/Util.php
@@ -42,7 +42,7 @@ final class Util
      * @return \DateTimeImmutable|null
      * @throws Exception
      */
-    public static function parseDate(string $dateString): \DateTimeImmutable
+    public static function parseDate(string $dateString): ?\DateTimeImmutable
     {
         if ($dateString === '') {
             return null;

--- a/src/Util.php
+++ b/src/Util.php
@@ -39,11 +39,15 @@ final class Util
      * Parse a date string from a Twinfield XML.
      *
      * @param string $dateString
-     * @return \DateTimeImmutable
+     * @return \DateTimeImmutable|null
      * @throws Exception
      */
     public static function parseDate(string $dateString): \DateTimeImmutable
     {
+        if ($dateString === '') {
+            return null;
+        }
+
         $date = \DateTimeImmutable::createFromFormat("Ymd|", $dateString);
 
         if (false === $date) {


### PR DESCRIPTION
Right now querying nullable dates from the browse API will cause an exception, in my case the matchdate on Supplier transactions (code 200)

The next line of code will cause an exception:
```php
(new BrowseColumn)->setField('fin.trs.line.matchdate')->setVisible(true),
```

Exception: `Invalid date, expected in yyyymmdd format, got "".`

With this PR no exception is thrown and a `BrowseDataCell` with value `null` is returned instead

I opted to not change the Util::parseDate and parseDateTime methods themselves, because they are used in other places as well.