### PR TITLE
Remove PerformanceType type from InvoiceLine

### DIFF
--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -187,12 +187,12 @@ class InvoiceLine
         return $this;
     }
 
-    public function getPerformanceType(): ?PerformanceType
+    public function getPerformanceType()
     {
         return $this->performanceType;
     }
 
-    public function setPerformanceType(?PerformanceType $performanceType): self
+    public function setPerformanceType($performanceType)
     {
         $this->performanceType = $performanceType;
         return $this;


### PR DESCRIPTION
When this is set, mapping an invoice won't work in the InvoiceMapper. This because the InvoiceMapper maps a string to this method, which would result in the following error:
```
TypeError: Argument 1 passed to PhpTwinfield\InvoiceLine::setPerformanceType() must be an instance of PhpTwinfield\Enums\PerformanceType or null, string given, called in x/vendor/php-twinfield/twinfield/src/Mappers/InvoiceMapper.php on line 107 and defined in x/vendor/php-twinfield/twinfield/src/InvoiceLine.php:195
```

Besides that, this is consistent with all other Enums (for example, Status).