### PR TITLE
Allow custom transaction classes to use invoice number and payment reference

### DIFF
--- a/src/DomDocuments/TransactionsDocument.php
+++ b/src/DomDocuments/TransactionsDocument.php
@@ -77,7 +77,7 @@ class TransactionsDocument extends BaseDocument
         }
 
         if (
-            in_array(InvoiceNumberField::class, class_uses($transaction)) &&
+            Util::objectUses(InvoiceNumberField::class, $transaction) &&
             $transaction->getInvoiceNumber() !== null
         ) {
             $invoiceNumberElement = $this->createNodeWithTextContent('invoicenumber', $transaction->getInvoiceNumber());
@@ -85,7 +85,7 @@ class TransactionsDocument extends BaseDocument
         }
 
         if (
-            in_array(PaymentReferenceField::class, class_uses($transaction)) &&
+            Util::objectUses(PaymentReferenceField::class, $transaction) &&
             $transaction->getPaymentReference() !== null
         ) {
             $paymentReferenceElement = $this->createNodeWithTextContent('paymentreference', $transaction->getPaymentReference());


### PR DESCRIPTION
When sending a custom transaction to Twinfield (one that extends one of the package transactions and doesn't directly use package traits), invoice number and payment reference will be skipped even if they are present. This PR fixes that by using the utility that already exists within the package.

The mapper side of things seems to be unaffected as it already uses this utility.