### PR TITLE
Change $messages default value to an empty array

### DIFF
--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -12,7 +12,7 @@ use PhpTwinfield\Message\Message;
 abstract class BaseObject
 {
     private $result;
-    private $messages;
+    private $messages = [];
 
     public function getResult()
     {


### PR DESCRIPTION
This prevents a `count(): Parameter must be an array or an object that implements Countable` warning on PHP 7.2 and above.