### PR TITLE
Fixing issue where default was converted to 0 or 1 in the xml

### DIFF
--- a/src/DomDocuments/SuppliersDocument.php
+++ b/src/DomDocuments/SuppliersDocument.php
@@ -2,6 +2,7 @@
 namespace PhpTwinfield\DomDocuments;
 
 use PhpTwinfield\Supplier;
+use PhpTwinfield\Util;
 
 /**
  * The Document Holder for making new XML customers. Is a child class
@@ -151,7 +152,7 @@ class SuppliersDocument extends \DOMDocument
                 $addressesElement->appendChild($addressElement);
 
                 // Set attributes
-                $addressElement->setAttribute('default', $address->getDefault());
+                $addressElement->setAttribute('default', Util::formatBoolean($address->getDefault()));
                 $addressElement->setAttribute('type', $address->getType());
 
                 // Go through each address element and use the assigned method


### PR DESCRIPTION
Address default attribute requires a string value of `true` or `false`. Currently booleans are converted to `0` or `1` when building the xml which makes the request fail.