### PR TITLE
Fix TransactionMapper to ignore 'line' elements that are not actually transaction lines

### DIFF
--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\Mappers;
 
+use DOMXPath;
 use Money\Currency;
 use Money\Money;
 use PhpTwinfield\BaseTransaction;
@@ -134,7 +135,7 @@ class TransactionMapper
         // Parse the transaction lines
         $transactionLineClassName = $transaction->getLineClassName();
 
-        foreach ($transactionElement->getElementsByTagName('line') as $lineElement) {
+        foreach ((new DOMXPath($document))->query('/transaction/lines/line') as $lineElement) {
             self::checkForMessage($transaction, $lineElement);
 
             /** @var BaseTransactionLine $transactionLine */


### PR DESCRIPTION
# Problem
Transactions sometimes have `<line>` elements that are not actually transaction lines (e.g. match lines), these lines will break the mapper as it tries to map them because information is missing.

# Solution
By using a XPath we only iterate over the `<line>` elements that are actually transaction lines

Closes #168 