### PR TITLE
Add support for transaction line match date

### DIFF
--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -22,6 +22,7 @@ use PhpTwinfield\Transactions\TransactionFields\FreeTextFields;
 use PhpTwinfield\Transactions\TransactionFields\InvoiceNumberField;
 use PhpTwinfield\Transactions\TransactionFields\PaymentReferenceField;
 use PhpTwinfield\Transactions\TransactionFields\StatementNumberField;
+use PhpTwinfield\Transactions\TransactionLineFields\MatchDateField;
 use PhpTwinfield\Transactions\TransactionLineFields\PerformanceFields;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueOpenField;
 use PhpTwinfield\Transactions\TransactionLineFields\VatTotalFields;
@@ -227,6 +228,14 @@ class TransactionMapper
                 $invoiceNumber = self::getField($transaction, $lineElement, 'invoicenumber');
                 if ($invoiceNumber) {
                     $transactionLine->setInvoiceNumber(self::getField($transaction, $lineElement, 'invoicenumber'));
+                }
+            }
+
+            if (Util::objectUses(MatchDateField::class, $transactionLine)) {
+                /** @var MatchDateField $transactionLine */
+                $matchDate = self::getField($transaction, $lineElement, 'matchdate');
+                if ($matchDate) {
+                    $transactionLine->setMatchDate(Util::parseDate($matchDate));
                 }
             }
 

--- a/src/PurchaseTransactionLine.php
+++ b/src/PurchaseTransactionLine.php
@@ -5,15 +5,14 @@ namespace PhpTwinfield;
 use Money\Money;
 use PhpTwinfield\Enums\DebitCredit;
 use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\Transactions\TransactionLineFields\MatchDateField;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueOpenField;
 use PhpTwinfield\Transactions\TransactionLineFields\VatTotalFields;
 use Webmozart\Assert\Assert;
 
-/**
- * @todo $matchDate Only if line type is total. The date on which the purchase invoice is matched. Read-only attribute.
- */
 class PurchaseTransactionLine extends BaseTransactionLine
 {
+    use MatchDateField;
     use VatTotalFields;
     use ValueOpenField;
 

--- a/src/SalesTransactionLine.php
+++ b/src/SalesTransactionLine.php
@@ -6,6 +6,7 @@ use Money\Money;
 use PhpTwinfield\Enums\DebitCredit;
 use PhpTwinfield\Enums\LineType;
 use PhpTwinfield\Transactions\TransactionFields\FreeTextFields;
+use PhpTwinfield\Transactions\TransactionLineFields\MatchDateField;
 use PhpTwinfield\Transactions\TransactionLineFields\PerformanceFields;
 use PhpTwinfield\Transactions\TransactionLineFields\ValueOpenField;
 use PhpTwinfield\Transactions\TransactionLineFields\VatTotalFields;
@@ -13,6 +14,7 @@ use Webmozart\Assert\Assert;
 
 class SalesTransactionLine extends BaseTransactionLine
 {
+    use MatchDateField;
     use VatTotalFields;
     use ValueOpenField;
     use PerformanceFields;

--- a/src/Transactions/TransactionLineFields/MatchDateField.php
+++ b/src/Transactions/TransactionLineFields/MatchDateField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpTwinfield\Transactions\TransactionLineFields;
+
+use DateTimeInterface;
+use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\Exception;
+
+trait MatchDateField
+{
+    /**
+     * @var DateTimeInterface|null Only if line type is total. Read-only attribute.
+     *                             The date on which the invoice is matched.
+     */
+    private $matchDate;
+
+    abstract public function getLineType(): LineType;
+
+    /**
+     * @return DateTimeInterface|null
+     */
+    public function getMatchDate(): ?DateTimeInterface
+    {
+        return $this->matchDate;
+    }
+
+    /**
+     * @param DateTimeInterface|null $matchDate
+     * @return $this
+     * @throws Exception
+     */
+    public function setMatchDate(?DateTimeInterface $matchDate): self
+    {
+        if ($matchDate !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
+            throw Exception::invalidFieldForLineType('matchdate', $this);
+        }
+
+        $this->matchDate = $matchDate;
+
+        return $this;
+    }
+}

--- a/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\IntegrationTests;
 
+use DateTime;
 use Money\Currency;
 use Money\Money;
 use PhpTwinfield\ApiConnectors\TransactionApiConnector;
@@ -90,6 +91,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertEquals(Money::EUR(2100), $totalLine->getVatTotal());
         $this->assertEquals(Money::EUR(2100), $totalLine->getVatBaseTotal());
         $this->assertEquals(Money::EUR(12100), $totalLine->getValueOpen());
+        $this->assertEquals(new DateTime('2020-12-03'), $totalLine->getMatchDate());
 
         $this->assertEquals(LineType::DETAIL(), $detailLine->getLineType());
         $this->assertSame(2, $detailLine->getId());
@@ -110,6 +112,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($detailLine->getVatTotal());
         $this->assertNull($detailLine->getVatBaseTotal());
         $this->assertNull($detailLine->getValueOpen());
+        $this->assertNull($detailLine->getMatchDate());
 
         $this->assertEquals(LineType::VAT(), $vatLine->getLineType());
         $this->assertSame(3, $vatLine->getId());
@@ -130,6 +133,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($vatLine->getVatTotal());
         $this->assertNull($vatLine->getVatBaseTotal());
         $this->assertNull($vatLine->getValueOpen());
+        $this->assertNull($vatLine->getMatchDate());
     }
 
     public function testSendPurchaseTransactionWorks()

--- a/tests/IntegrationTests/resources/purchaseTransactionGetResponse.xml
+++ b/tests/IntegrationTests/resources/purchaseTransactionGetResponse.xml
@@ -31,6 +31,7 @@
             <openbasevalue>121.00</openbasevalue>
             <openrepvalue>156.53</openrepvalue>
             <matchstatus>available</matchstatus>
+            <matchdate>20201203</matchdate>
         </line>
         <line type="detail" id="2">
             <dim1 name="Omzet (19%)" shortname="Omzet (19%)" type="PNL" inuse="true" vatcode="" vatobligatory="false">8020</dim1>


### PR DESCRIPTION
The value of `<matchdate>` is currently not retrievable from transactions, this PR aims to fix this.

This PR adds `getMatchDate()` and `setMatchDate()` to `PurchaseTransactionLine` and `SalesTransactionLine`*
This matchDate attribute may only be set on total lines (per [documentation](https://accounting2.twinfield.com/webservices/documentation/#/ApiReference/PurchaseTransactions)), and will throw if an attempt is made for it to be set on another line type.

*The documentation only mentions `<matchdate>` for the purchase transaction, however testing the actual API revealed that this element is also present in get responses on sales transactions.