### PR TITLE
Added raise warning field to invoice document

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "php-twinfield/twinfield",
+  "name": "pidz-development/twinfield",
   "type": "library",
-  "description": "Library for using the Twinfield Soap Service.",
+  "description": "Fork of Library for using the Twinfield Soap Service.",
   "keywords": [
     "twinfield"
   ],
@@ -15,6 +15,10 @@
     {
       "name": "Leon Rowland",
       "email": "leon@pronamic.nl"
+    },
+    {
+      "name": "Peter van den Broek",
+      "email": "peter.vandenbroek@pidz.nl"
     }
   ],
   "config": {

--- a/src/DomDocuments/InvoicesDocument.php
+++ b/src/DomDocuments/InvoicesDocument.php
@@ -36,6 +36,9 @@ class InvoicesDocument extends BaseDocument
     {
         // Make a new <salesinvoice> element
         $invoiceElement = $this->createElement('salesinvoice');
+        if ($invoice->getRaiseWarning() !== null) {
+            $invoiceElement->appendChild($this->createBooleanAttribute('raisewarning', $invoice->getRaiseWarning()));
+        }
 
         // Makes a child header element
         $headerElement = $this->createElement('header');

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -3,6 +3,7 @@ namespace PhpTwinfield;
 
 use PhpTwinfield\Transactions\TransactionFields\DueDateField;
 use PhpTwinfield\Transactions\TransactionFields\OfficeField;
+use PhpTwinfield\Transactions\TransactionFields\RaiseWarningField;
 use PhpTwinfield\Transactions\TransactionLineFields\PeriodField;
 
 /**
@@ -31,6 +32,7 @@ class Invoice
     use PeriodField;
     use DueDateField;
     use OfficeField;
+    use RaiseWarningField;
 
     private $customer;
     private $invoiceType;


### PR DESCRIPTION
Add the raise warning field to InvoiceDocument so you can supress warnings on SalesInvoice level

See https://accounting.twinfield.com/webservices/documentation/#/ApiReference/SalesInvoices
