### PR TITLE
Support PHP 8 and Money 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.settings/
 /.idea/
 /.buildpath
+/.phpunit.result.cache
 /.project
 /.idea
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: bionic
 
 php:
 - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: php
 dist: trusty
 
 php:
-- 7.1
-- 7.2
 - 7.3
 - 7.4
+- 8.0
 
 matrix:
   fast_finish: true
@@ -24,6 +23,5 @@ install:
 script:
 - composer validate --strict
 - find src tests -name '*.php' | xargs -n 1 -P4 php -l
-- composer dependency-guard
 - vendor/bin/phpunit --fail-on-risky
 - vendor/bin/phpstan analyse --level 0 src tests

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "pronamic/twinfield": "*"
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.3",
     "ext-dom": "*",
     "ext-json": "*",
     "ext-soap": "*",
-    "moneyphp/money": "^3.0",
+    "moneyphp/money": "^3.0 || ^4.0",
     "myclabs/php-enum": "^1.5",
     "psr/http-message": "^1.0",
     "psr/log": "^1.0",
@@ -53,8 +53,7 @@
   "require-dev": {
     "eloquent/liberator": "^2.0",
     "league/oauth2-client": "^2.2",
-    "mediact/dependency-guard": "^1.0",
-    "phpstan/phpstan": "^0.10.1",
-    "phpunit/phpunit": "^7.3"
+    "phpstan/phpstan": "^0.12.88",
+    "phpunit/phpunit": "^9.5"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,2 @@
 parameters:
 	ignoreErrors:
-		- '#Call to an undefined static method SoapClient::__construct()#'

--- a/src/ApiConnectors/ArticleApiConnector.php
+++ b/src/ApiConnectors/ArticleApiConnector.php
@@ -55,11 +55,7 @@ class ArticleApiConnector extends BaseApiConnector
      */
     public function send(Article $article): Article
     {
-        $articleResponses = $this->sendAll([$article]);
-
-        Assert::count($articleResponses, 1);
-
-        return $articleResponses->getIterator()->current()->unwrap();
+        return $this->unwrapSingleResponse($this->sendAll([$article]));
     }
 
     /**

--- a/src/ApiConnectors/ArticleApiConnector.php
+++ b/src/ApiConnectors/ArticleApiConnector.php
@@ -59,9 +59,7 @@ class ArticleApiConnector extends BaseApiConnector
 
         Assert::count($articleResponses, 1);
 
-        foreach ($articleResponses as $articleResponse) {
-            return $articleResponse->unwrap();
-        }
+        return $articleResponses->getIterator()->current()->unwrap();
     }
 
     /**

--- a/src/ApiConnectors/BankTransactionApiConnector.php
+++ b/src/ApiConnectors/BankTransactionApiConnector.php
@@ -28,9 +28,7 @@ class BankTransactionApiConnector extends BaseApiConnector
 
         Assert::count($bankTransactionResponses, 1);
 
-        foreach ($bankTransactionResponses as $bankTransactionResponse) {
-            return $bankTransactionResponse->unwrap();
-        }
+        return $bankTransactionResponses->getIterator()->current()->unwrap();
     }
 
     /**

--- a/src/ApiConnectors/BankTransactionApiConnector.php
+++ b/src/ApiConnectors/BankTransactionApiConnector.php
@@ -24,11 +24,7 @@ class BankTransactionApiConnector extends BaseApiConnector
      */
     public function send(BankTransaction $bankTransaction): BankTransaction
     {
-        $bankTransactionResponses = $this->sendAll([$bankTransaction]);
-
-        Assert::count($bankTransactionResponses, 1);
-
-        return $bankTransactionResponses->getIterator()->current()->unwrap();
+        return $this->unwrapSingleResponse($this->sendAll([$bankTransaction]));
     }
 
     /**

--- a/src/ApiConnectors/BaseApiConnector.php
+++ b/src/ApiConnectors/BaseApiConnector.php
@@ -4,6 +4,7 @@ namespace PhpTwinfield\ApiConnectors;
 
 use PhpTwinfield\Enums\Services;
 use PhpTwinfield\Exception;
+use PhpTwinfield\Response\MappedResponseCollection;
 use PhpTwinfield\Response\Response;
 use PhpTwinfield\Secure\AuthenticatedConnection;
 use PhpTwinfield\Services\FinderService;
@@ -13,6 +14,7 @@ use PhpTwinfield\Services\SessionService;
 use PhpTwinfield\Util;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Webmozart\Assert\Assert;
 
 abstract class BaseApiConnector implements LoggerAwareInterface
 {
@@ -106,6 +108,12 @@ abstract class BaseApiConnector implements LoggerAwareInterface
             $this->logFailedRequest($exception);
             throw new Exception($exception->getMessage(), 0, $exception);
         }
+    }
+
+    final protected function unwrapSingleResponse(MappedResponseCollection $responses) {
+        Assert::count($responses, 1);
+
+        return $responses->getIterator()->current()->unwrap();
     }
 
     private function logSendingDocument(\DOMDocument $document): void

--- a/src/ApiConnectors/CustomerApiConnector.php
+++ b/src/ApiConnectors/CustomerApiConnector.php
@@ -99,9 +99,7 @@ class CustomerApiConnector extends BaseApiConnector
 
         Assert::count($customerResponses, 1);
 
-        foreach ($customerResponses as $customerResponse) {
-            return $customerResponse->unwrap();
-        }
+        return $customerResponses->getIterator()->current()->unwrap();
     }
 
     /**

--- a/src/ApiConnectors/CustomerApiConnector.php
+++ b/src/ApiConnectors/CustomerApiConnector.php
@@ -95,11 +95,7 @@ class CustomerApiConnector extends BaseApiConnector
      */
     public function send(Customer $customer): Customer
     {
-        $customerResponses = $this->sendAll([$customer]);
-
-        Assert::count($customerResponses, 1);
-
-        return $customerResponses->getIterator()->current()->unwrap();
+        return $this->unwrapSingleResponse($this->sendAll([$customer]));
     }
 
     /**

--- a/src/ApiConnectors/InvoiceApiConnector.php
+++ b/src/ApiConnectors/InvoiceApiConnector.php
@@ -61,9 +61,7 @@ class InvoiceApiConnector extends BaseApiConnector
 
         Assert::count($invoiceResponses, 1);
 
-        foreach ($invoiceResponses as $invoiceResponse) {
-            return $invoiceResponse->unwrap();
-        }
+        return $invoiceResponses->getIterator()->current()->unwrap();
     }
 
     /**

--- a/src/ApiConnectors/InvoiceApiConnector.php
+++ b/src/ApiConnectors/InvoiceApiConnector.php
@@ -57,11 +57,7 @@ class InvoiceApiConnector extends BaseApiConnector
      */
     public function send(Invoice $invoice): Invoice
     {
-        $invoiceResponses = $this->sendAll([$invoice]);
-
-        Assert::count($invoiceResponses, 1);
-
-        return $invoiceResponses->getIterator()->current()->unwrap();
+        return $this->unwrapSingleResponse($this->sendAll([$invoice]));
     }
 
     /**

--- a/src/ApiConnectors/SupplierApiConnector.php
+++ b/src/ApiConnectors/SupplierApiConnector.php
@@ -98,11 +98,7 @@ class SupplierApiConnector extends BaseApiConnector
      */
     public function send(Supplier $supplier): Supplier
     {
-        $supplierResponses = $this->sendAll([$supplier]);
-
-        Assert::count($supplierResponses, 1);
-
-        return $supplierResponses->getIterator()->current()->unwrap();
+        return $this->unwrapSingleResponse($this->sendAll([$supplier]));
     }
 
 

--- a/src/ApiConnectors/SupplierApiConnector.php
+++ b/src/ApiConnectors/SupplierApiConnector.php
@@ -102,9 +102,7 @@ class SupplierApiConnector extends BaseApiConnector
 
         Assert::count($supplierResponses, 1);
 
-        foreach ($supplierResponses as $supplierResponse) {
-            return $supplierResponse->unwrap();
-        }
+        return $supplierResponses->getIterator()->current()->unwrap();
     }
 
 

--- a/src/ApiConnectors/TransactionApiConnector.php
+++ b/src/ApiConnectors/TransactionApiConnector.php
@@ -58,9 +58,7 @@ class TransactionApiConnector extends BaseApiConnector
      */
     public function send(BaseTransaction $transaction): BaseTransaction
     {
-        foreach($this->sendAll([$transaction]) as $each) {
-            return $each->unwrap();
-        }
+        return $this->sendAll([$transaction])->getIterator()->current()->unwrap();
     }
 
     /**

--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -152,11 +152,11 @@ class TransactionMapper
                 ->setId($lineElement->getAttribute('id'))
                 ->setDim1(self::getField($transaction, $lineElement, 'dim1'))
                 ->setDim2(self::getField($transaction, $lineElement, 'dim2'))
-                ->setValue(Money::EUR(100 * self::getField($transaction, $lineElement, 'value')))
+                ->setValue(self::getFieldAsMoneyObject($transaction, $lineElement, 'value'))
                 ->setDebitCredit(new DebitCredit(self::getField($transaction, $lineElement, 'debitcredit')))
-                ->setBaseValue(Money::EUR(100 * self::getField($transaction, $lineElement, 'basevalue')))
+                ->setBaseValue(self::getFieldAsMoneyObject($transaction, $lineElement, 'basevalue'))
                 ->setRate(self::getField($transaction, $lineElement, 'rate'))
-                ->setRepValue(Money::EUR(100 * self::getField($transaction, $lineElement, 'repvalue')))
+                ->setRepValue(self::getFieldAsMoneyObject($transaction, $lineElement, 'repvalue'))
                 ->setRepRate(self::getField($transaction, $lineElement, 'reprate'))
                 ->setDescription(self::getField($transaction, $lineElement, 'description'))
                 ->setMatchStatus(self::getField($transaction, $lineElement, 'matchstatus'))
@@ -164,14 +164,14 @@ class TransactionMapper
                 ->setVatCode(self::getField($transaction, $lineElement, 'vatcode'));
 
             // TODO - according to the docs, the field is called <basevalueopen>, but the examples use <openbasevalue>.
-            $baseValueOpen = self::getField($transaction, $lineElement, 'basevalueopen') ?: self::getField($transaction, $lineElement, 'openbasevalue');
+            $baseValueOpen = self::getFieldAsMoneyObject($transaction, $lineElement, 'basevalueopen') ?: self::getFieldAsMoneyObject($transaction, $lineElement, 'openbasevalue');
             if ($baseValueOpen) {
-                $transactionLine->setBaseValueOpen(Money::EUR(100 * $baseValueOpen));
+                $transactionLine->setBaseValueOpen($baseValueOpen);
             }
 
-            $vatValue = self::getField($transaction, $lineElement, 'vatvalue');
+            $vatValue = self::getFieldAsMoneyObject($transaction, $lineElement, 'vatvalue');
             if ($lineType == LineType::DETAIL() && $vatValue) {
-                $transactionLine->setVatValue(Money::EUR(100 * $vatValue));
+                $transactionLine->setVatValue($vatValue);
             }
 
             $baseline = self::getField($transaction, $lineElement, 'baseline');
@@ -212,20 +212,20 @@ class TransactionMapper
             }
             if (in_array(ValueOpenField::class, class_uses($transactionLine))) {
                 // TODO - according to the docs, the field is called <valueopen>, but the examples use <openvalue>.
-                $valueOpen = self::getField($transaction, $lineElement, 'valueopen') ?: self::getField($transaction, $lineElement, 'openvalue');
+                $valueOpen = self::getFieldAsMoneyObject($transaction, $lineElement, 'valueopen') ?: self::getFieldAsMoneyObject($transaction, $lineElement, 'openvalue');
                 if ($valueOpen) {
-                    $transactionLine->setValueOpen(Money::EUR(100 * $valueOpen));
+                    $transactionLine->setValueOpen($valueOpen);
                 }
             }
             if (in_array(VatTotalFields::class, class_uses($transactionLine))) {
-                $vatTotal = self::getField($transaction, $lineElement, 'vattotal');
+                $vatTotal = self::getFieldAsMoneyObject($transaction, $lineElement, 'vattotal');
                 if ($vatTotal) {
-                    $transactionLine->setVatTotal(Money::EUR(100 * $vatTotal));
+                    $transactionLine->setVatTotal($vatTotal);
                 }
 
-                $vatBaseTotal = self::getField($transaction, $lineElement, 'vatbasetotal');
+                $vatBaseTotal = self::getFieldAsMoneyObject($transaction, $lineElement, 'vatbasetotal');
                 if ($vatBaseTotal) {
-                    $transactionLine->setVatBaseTotal(Money::EUR(100 * $vatBaseTotal));
+                    $transactionLine->setVatBaseTotal($vatBaseTotal);
                 }
             }
             if (Util::objectUses(InvoiceNumberField::class, $transactionLine)) {
@@ -261,6 +261,20 @@ class TransactionMapper
         self::checkForMessage($transaction, $fieldElement);
 
         return $fieldElement->textContent;
+    }
+
+    private static function getFieldAsMoneyObject(
+        BaseTransaction $transaction,
+        \DOMElement $element,
+        string $fieldTagName
+    ): ?Money {
+        $fieldValue = self::getField($transaction, $element, $fieldTagName);
+
+        if ($fieldValue === null) {
+            return null;
+        }
+
+        return Money::EUR((string)(100 * $fieldValue));
     }
 
     private static function checkForMessage(BaseTransaction $transaction, \DOMElement $element): void

--- a/src/Mappers/TransactionMapper.php
+++ b/src/Mappers/TransactionMapper.php
@@ -31,6 +31,8 @@ use PhpTwinfield\Util;
 
 class TransactionMapper
 {
+    private const DEFAULT_CURRENCY_CODE = 'EUR';
+
     /**
      * @param string   $transactionClassName
      * @param Response $response
@@ -94,7 +96,7 @@ class TransactionMapper
             ->setFreetext2(self::getField($transaction, $transactionElement, 'freetext2'))
             ->setFreetext3(self::getField($transaction, $transactionElement, 'freetext3'));
 
-        $currency = new Currency(self::getField($transaction, $transactionElement, 'currency') ?? 'EUR');
+        $currency = new Currency(self::getField($transaction, $transactionElement, 'currency') ?? self::DEFAULT_CURRENCY_CODE);
         $transaction->setCurrency($currency);
 
         $number = self::getField($transaction, $transactionElement, 'number');

--- a/tests/IntegrationTests/BaseIntegrationTest.php
+++ b/tests/IntegrationTests/BaseIntegrationTest.php
@@ -38,7 +38,7 @@ abstract class BaseIntegrationTest extends TestCase
      */
     protected $sessionService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/BrowseDataApiConnectorTest.php
+++ b/tests/IntegrationTests/BrowseDataApiConnectorTest.php
@@ -16,7 +16,7 @@ class BrowseDataApiConnectorTest extends BaseIntegrationTest
     private $browseDataApiConnector;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/CashTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/CashTransactionIntegrationTest.php
@@ -32,7 +32,7 @@ class CashTransactionIntegrationTest extends BaseIntegrationTest
      */
     private $transactionApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/CustomerIntegrationTest.php
+++ b/tests/IntegrationTests/CustomerIntegrationTest.php
@@ -30,7 +30,7 @@ class CustomerIntegrationTest extends BaseIntegrationTest
      */
     private $customerApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/InvoiceIntegrationTest.php
+++ b/tests/IntegrationTests/InvoiceIntegrationTest.php
@@ -27,7 +27,7 @@ class InvoiceIntegrationTest extends BaseIntegrationTest
      */
     private $invoiceApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/JournalTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/JournalTransactionIntegrationTest.php
@@ -29,7 +29,7 @@ class JournalTransactionIntegrationTest extends BaseIntegrationTest
      */
     private $transactionApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/OfficeIntegrationTest.php
+++ b/tests/IntegrationTests/OfficeIntegrationTest.php
@@ -13,7 +13,7 @@ class OfficeIntegrationTest extends BaseIntegrationTest
      */
     private $officeApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
@@ -30,7 +30,7 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
      */
     private $transactionApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->transactionApiConnector = new TransactionApiConnector($this->connection);

--- a/tests/IntegrationTests/SalesTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/SalesTransactionIntegrationTest.php
@@ -29,7 +29,7 @@ class SalesTransactionIntegrationTest extends BaseIntegrationTest
      */
     private $transactionApiConnector;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/ApiConnectors/BankTransactionApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BankTransactionApiConnectorTest.php
@@ -37,7 +37,7 @@ class BankTransactionApiConnectorTest extends TestCase
      */
     protected $office;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -229,12 +229,11 @@ class BankTransactionApiConnectorTest extends TestCase
         $this->assertEquals(Money::EUR(10000), $line->getVatBaseTurnover());
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage De status van de boeking moet Concept zijn
-     */
     public function testDeleteThrowsWhenResponseContainsErrorMessages()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('De status van de boeking moet Concept zijn');
+
         $bookingReference = new BookingReference(Office::fromCode("OFFICE001"), "BNK", 201700006);
 
         $this->processXmlService->expects($this->once())

--- a/tests/UnitTests/ApiConnectors/BrowseDataApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BrowseDataApiConnectorTest.php
@@ -22,7 +22,7 @@ class BrowseDataApiConnectorTest extends TestCase
      */
     protected $processXmlService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/ApiConnectors/CustomerApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/CustomerApiConnectorTest.php
@@ -21,7 +21,7 @@ class CustomerApiConnectorTest extends TestCase
      */
     protected $processXmlService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/ApiConnectors/MatchesApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/MatchesApiConnectorTest.php
@@ -25,7 +25,7 @@ class MatchesApiConnectorTest extends TestCase
      */
     protected $processXmlService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/ApiConnectors/TransactionApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/TransactionApiConnectorTest.php
@@ -25,7 +25,7 @@ class TransactionApiConnectorTest extends TestCase
      */
     protected $processXmlService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/CashTransactionLineUnitTest.php
+++ b/tests/UnitTests/CashTransactionLineUnitTest.php
@@ -16,7 +16,7 @@ class CashTransactionLineUnitTest extends \PHPUnit\Framework\TestCase
      */
     private $line;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->line = new CashTransactionLine();
     }

--- a/tests/UnitTests/CashTransactionUnitTest.php
+++ b/tests/UnitTests/CashTransactionUnitTest.php
@@ -16,7 +16,7 @@ class CashTransactionUnitTest extends \PHPUnit\Framework\TestCase
      */
     private $cashTransaction;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cashTransaction = new CashTransaction();
     }

--- a/tests/UnitTests/DomDocuments/BankTransactionDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/BankTransactionDocumentUnitTest.php
@@ -18,7 +18,7 @@ class BankTransactionDocumentUnitTest extends \PHPUnit\Framework\TestCase
      */
     protected $document;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/CustomersDocumentUnitTest.php
@@ -17,7 +17,7 @@ class CustomersDocumentUnitTest extends TestCase
      */
     protected $document;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/DomDocuments/MatchDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/MatchDocumentUnitTest.php
@@ -18,7 +18,7 @@ class MatchDocumentUnitTest extends \PHPUnit\Framework\TestCase
 {
     protected $office;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/ElectronicBankStatementUnitTest.php
+++ b/tests/UnitTests/ElectronicBankStatementUnitTest.php
@@ -20,11 +20,10 @@ class ElectronicBankStatementUnitTest extends TestCase
         $this->assertEquals("HUF", $ebs->getCurrency());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCannotChangeCurrencyOnceValueIsSet()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $ebs = new ElectronicBankStatement();
         $ebs->setStartvalue(Money::GBP(1));
 

--- a/tests/UnitTests/Request/MappedResponseCollectionUnitTest.php
+++ b/tests/UnitTests/Request/MappedResponseCollectionUnitTest.php
@@ -19,7 +19,7 @@ class MappedResponseCollectionUnitTest extends TestCase
      */
     protected $processXmlService;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/Request/ResponseUnitTest.php
+++ b/tests/UnitTests/Request/ResponseUnitTest.php
@@ -21,12 +21,11 @@ class ResponseUnitTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
     }
 
-    /**
-     * @expectedException \PhpTwinfield\Exception
-     * @expectedExceptionMessage Not all items were processed successfully by Twinfield: 0 success / 1 failed.
-     */
     public function testMultipleItemsSentIsNotSuccessFul()
     {
+        $this->expectException(\PhpTwinfield\Exception::class);
+        $this->expectExceptionMessage('Not all items were processed successfully by Twinfield: 0 success / 1 failed.');
+
         $response = Response::fromString('<?xml version="1.0"?>
 <statements target="electronicstatements" importduplicate="0">
     <statement target="electronicstatements" result="0">

--- a/tests/UnitTests/SalesTransactionLineUnitTest.php
+++ b/tests/UnitTests/SalesTransactionLineUnitTest.php
@@ -15,7 +15,7 @@ class SalesTransactionLineUnitTest extends \PHPUnit\Framework\TestCase
      */
     private $line;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->line = new SalesTransactionLine();
     }

--- a/tests/UnitTests/Secure/OpenIdConnectionAuthenticationTest.php
+++ b/tests/UnitTests/Secure/OpenIdConnectionAuthenticationTest.php
@@ -18,7 +18,7 @@ class OpenIdConnectionAuthenticationTest extends TestCase
      */
     private $openIdProvider;
 
-    protected function SetUp()
+    protected function setUp(): void
     {
         $this->openIdProvider = $this->getMockBuilder(OAuthProvider::class)
             ->setMethods([ "getAccessToken" ])

--- a/tests/UnitTests/Secure/Provider/OAuthProviderTest.php
+++ b/tests/UnitTests/Secure/Provider/OAuthProviderTest.php
@@ -26,7 +26,7 @@ class OAuthProviderTest extends TestCase
      */
     protected $token;
 
-    protected function SetUp()
+    protected function setUp(): void
     {
         $this->httpClient = $this->createMock(ClientInterface::class);
         $this->provider = new OAuthProvider([

--- a/tests/UnitTests/Supplier/OfficeTest.php
+++ b/tests/UnitTests/Supplier/OfficeTest.php
@@ -16,7 +16,7 @@ class SupplierOfficeTest extends \PHPUnit\Framework\TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/Supplier/OfficeTest.php
+++ b/tests/UnitTests/Supplier/OfficeTest.php
@@ -5,7 +5,7 @@ use PhpTwinfield\DomDocuments\SuppliersDocument;
 use PhpTwinfield\Office;
 use PhpTwinfield\Supplier;
 
-class SupplierOfficeTest extends \PHPUnit\Framework\TestCase
+class OfficeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Office


### PR DESCRIPTION
This PR moves the supported version of the library to match the currently supported version of PHP:

- Support for 7.1 and 7.2 is dropped.
- Support for 8.0 is added.

Unfortunately `mediact/dependency-guard` does not have a PHP 8 compatible release yet, so I dropped it.
I've upgraded PHPStan and PHPUnit to versions that do support it.

I do understand dropping `dependency-guard` can be a deal breaker. I'd like you to consider allowing `moneyphp/money 4.0` in that case.