### PR TITLE
feat: added list all ledger accounts connector

### DIFF
--- a/src/ApiConnectors/LedgerAccountApiConnector.php
+++ b/src/ApiConnectors/LedgerAccountApiConnector.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpTwinfield\ApiConnectors;
+
+use PhpTwinfield\LedgerAccount;
+use PhpTwinfield\Services\FinderService;
+
+class LedgerAccountApiConnector extends BaseApiConnector
+{
+    /**
+     * List all ledger accounts.
+     *
+     * @param string $pattern  The search pattern. May contain wildcards * and ?
+     * @param int    $field    The search field determines which field or fields will be searched. The available fields
+     *                         depends on the finder type. Passing a value outside the specified values will cause an
+     *                         error.
+     * @param int    $firstRow First row to return, useful for paging
+     * @param int    $maxRows  Maximum number of rows to return, useful for paging
+     * @param array  $options  The Finder options. Passing an unsupported name or value causes an error. It's possible
+     *                         to add multiple options. An option name may be used once, specifying an option multiple
+     *                         times will cause an error.
+     *
+     * @return LedgerAccount[] The found ledger accounts.
+     */
+    public function listAll(
+        string $pattern = '*',
+        int $field = 0,
+        int $firstRow = 1,
+        int $maxRows = 100,
+        array $options = []
+    ): array {
+        $response = $this->getFinderService()
+            ->searchFinder(
+                FinderService::TYPE_DIMENSIONS_FINANCIALS,
+                $pattern,
+                $field,
+                $firstRow,
+                $maxRows,
+                $options
+            );
+
+        if ($response->data->TotalRows == 0) {
+            return [];
+        }
+
+        $ledgerAccounts = [];
+        foreach ($response->data->Items->ArrayOfString as $ledgerAccountArray) {
+            $ledgerAccount = new LedgerAccount();
+            $ledgerAccount->setCode($ledgerAccountArray->string[0]);
+            $ledgerAccount->setName($ledgerAccountArray->string[1]);
+            $ledgerAccounts[] = $ledgerAccount;
+        }
+
+        return $ledgerAccounts;
+    }
+}

--- a/src/LedgerAccount.php
+++ b/src/LedgerAccount.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpTwinfield;
+
+/**
+ * Class LedgerAccount
+ */
+class LedgerAccount
+{
+    /**
+     * @var string The code of the ledger account.
+     */
+    private $code;
+
+    /**
+     * @var string The name of the ledger account.
+     */
+    private $name;
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): void
+    {
+        $this->code = $code;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
I've added the Ledger Account connector, based on the documentation: https://accounting.twinfield.com/webservices/documentation/#/ApiReference/Masters/BalanceSheets
The code is similar/identical to that of the VatCodeApiConnector.

We require this functionality for a project.