### PR TITLE
Adding ability to fetch VAT code details

### DIFF
--- a/src/Account.php
+++ b/src/Account.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTwinfield;
+
+use PhpTwinfield\Enums\LineType;
+
+final class Account
+{
+    private $id;
+    private $dim1;
+    private $groupCountry;
+    private $group;
+    private $percentage;
+    private $lineType;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId($id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getDim1(): string
+    {
+        return $this->dim1;
+    }
+
+    public function setDim1(string $dim1): self
+    {
+        $this->dim1 = $dim1;
+        return $this;
+    }
+
+    public function getGroupCountry(): string
+    {
+        return $this->groupCountry;
+    }
+
+    public function setGroupCountry(string $groupCountry): self
+    {
+        $this->groupCountry = $groupCountry;
+        return $this;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    public function setGroup(string $group): self
+    {
+        $this->group = $group;
+        return $this;
+    }
+
+    public function getPercentage(): float
+    {
+        return $this->percentage;
+    }
+
+    public function setPercentage(float $percentage): self
+    {
+        $this->percentage = $percentage;
+        return $this;
+    }
+
+    public function getLineType(): LineType
+    {
+        return $this->lineType;
+    }
+
+    public function setLineType(LineType $lineType): self
+    {
+        $this->lineType = $lineType;
+        return $this;
+    }
+}

--- a/src/ApiConnectors/VatCodeApiConnector.php
+++ b/src/ApiConnectors/VatCodeApiConnector.php
@@ -2,7 +2,10 @@
 
 namespace PhpTwinfield\ApiConnectors;
 
+use PhpTwinfield\Mappers\VatMapper;
+use PhpTwinfield\Office;
 use PhpTwinfield\Services\FinderService;
+use PhpTwinfield\VatCodeDetail;
 use PhpTwinfield\VatCode;
 
 /**
@@ -53,5 +56,15 @@ class VatCodeApiConnector extends BaseApiConnector
         }
 
         return $vatCodes;
+    }
+
+    public function get(string $code, Office $office): VatCodeDetail
+    {
+        $response = $this->sendXmlDocument(new \PhpTwinfield\Request\Read\VatCode(
+            $office,
+            $code,
+        ));
+
+        return VatMapper::map($response);
     }
 }

--- a/src/Mappers/VatMapper.php
+++ b/src/Mappers/VatMapper.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTwinfield\Mappers;
+
+use PhpTwinfield\Account;
+use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\Response\Response;
+use PhpTwinfield\VatCodeDetail;
+use PhpTwinfield\VatCodePercentage;
+
+final class VatMapper extends BaseMapper
+{
+    /**
+     * Maps a Response object to a clean Vat entity.
+     *
+     * @access public
+     * @param \PhpTwinfield\Response\Response $response
+     * @return VatCodeDetail
+     */
+    public static function map(Response $response): VatCodeDetail
+    {
+        $vatCodeDetail = new VatCodeDetail();
+
+        // Gets the raw DOMDocument response.
+        $responseDOM = $response->getResponseDocument();
+
+        // Set the status attribute
+        $vatElement = $responseDOM->getElementsByTagName('vat')->item(0);
+        $vatCodeDetail->setStatus($vatElement->getAttribute('status'));
+
+        // Vat elements and their methods
+        $vatTags = [
+            'code' => 'setCode',
+            'name' => 'setName',
+            'shortname' => 'setShortName',
+            'uid' => 'setUID',
+            'created' => 'setCreatedFromString',
+            'modified' => 'setModifiedFromString',
+            'touched' => 'setTouched',
+            'type' => 'setType',
+            'user' => 'setUser',
+        ];
+
+        // Loop through all the tags
+        foreach ($vatTags as $tag => $method) {
+            self::setFromTagValue($responseDOM, $tag, [$vatCodeDetail, $method]);
+        }
+
+        $xpath = new \DOMXPath($responseDOM);
+        $percentages = [];
+        foreach ($xpath->query('/vat/percentages/percentage', $vatElement) as $percentageNode) {
+            $percentages[] = $percentage = new VatCodePercentage();
+
+            $percentage
+                ->setStatus($percentageNode->getAttribute('status'))
+                ->setInUse($percentageNode->getAttribute('inuse') === 'true')
+                ->setDateFromString(self::getField($percentageNode, 'date'))
+                ->setPercentage((float) self::getField($percentageNode, 'percentage'))
+                ->setCreatedFromString(self::getField($percentageNode, 'created'))
+                ->setName(self::getField($percentageNode, 'name'))
+                ->setShortname(self::getField($percentageNode, 'shortname'))
+                ->setUser(self::getField($percentageNode, 'user'));
+
+            $accounts = [];
+            foreach ($xpath->query('accounts/account', $percentageNode) as $accountNode) {
+                $accounts[] = $account = new Account();
+
+                $account
+                    ->setId($accountNode->getAttribute('id'))
+                    ->setDim1(self::getField($accountNode, 'dim1'))
+                    ->setGroupCountry(self::getField($accountNode, 'groupcountry'))
+                    ->setGroup(self::getField($accountNode, 'group'))
+                    ->setPercentage((float) self::getField($accountNode, 'percentage'))
+                    ->setLineType(new LineType(self::getField($accountNode, 'linetype')));
+            }
+
+            $percentage->setAccounts($accounts);
+        }
+        $vatCodeDetail->setPercentages($percentages);
+
+        return $vatCodeDetail;
+    }
+}

--- a/src/Request/Read/VatCode.php
+++ b/src/Request/Read/VatCode.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTwinfield\Request\Read;
+
+final class VatCode extends Read
+{
+    public function __construct(string $office, string $code)
+    {
+        parent::__construct();
+
+        $this->add('type', 'vat');
+
+        $this->add('office', $office);
+        $this->add('code', $code);
+    }
+}

--- a/src/VatCodeDetail.php
+++ b/src/VatCodeDetail.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTwinfield;
+
+use PhpTwinfield\Transactions\TransactionFields\OfficeField;
+use Webmozart\Assert\Assert;
+
+final class VatCodeDetail
+{
+    use OfficeField;
+
+    private $status;
+    private $code;
+    private $name;
+    private $shortName;
+    private $uid;
+    private $created;
+    private $modified;
+    private $touched;
+    private $type;
+    private $user;
+    private $percentages = [];
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getShortName(): string
+    {
+        return $this->shortName;
+    }
+
+    public function setShortName(string $shortName): self
+    {
+        $this->shortName = $shortName;
+        return $this;
+    }
+
+    public function getUID(): string
+    {
+        return $this->uid;
+    }
+
+    public function setUID(string $uid): self
+    {
+        $this->uid = $uid;
+        return $this;
+    }
+
+    public function getCreated(): \DateTimeInterface
+    {
+        return $this->created;
+    }
+
+    public function setCreatedFromString(string $dateStr): self
+    {
+        $this->created = Util::parseDateTime($dateStr);
+        return $this;
+    }
+
+    public function getModified(): \DateTimeInterface
+    {
+        return $this->created;
+    }
+
+    public function setModifiedFromString(string $dateStr): self
+    {
+        $this->modified = Util::parseDateTime($dateStr);
+        return $this;
+    }
+
+    public function getTouched(): int
+    {
+        return $this->touched;
+    }
+
+    public function setTouched(int $touched): self
+    {
+        $this->touched = $touched;
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function setUser(string $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * @return VatCodePercentage[]
+     */
+    public function getPercentages(): array
+    {
+        return $this->percentages;
+    }
+
+    public function setPercentages(array $percentages): self
+    {
+        Assert::allIsInstanceOf($percentages, VatCodePercentage::class);
+
+        $this->percentages = $percentages;
+        return $this;
+    }
+}

--- a/src/VatCodePercentage.php
+++ b/src/VatCodePercentage.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTwinfield;
+
+use Webmozart\Assert\Assert;
+
+final class VatCodePercentage
+{
+    private $status;
+    private $inUse;
+    private $date;
+    private $percentage;
+    private $created;
+    private $name;
+    private $shortname;
+    private $user;
+    private $accounts = [];
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function isInUse(): bool
+    {
+        return $this->inUse;
+    }
+
+    public function setInUse(bool $inUse): self
+    {
+        $this->inUse = $inUse;
+        return $this;
+    }
+
+    public function getDate(): \DateTimeInterface
+    {
+        return $this->date;
+    }
+
+    public function setDateFromString(string $dateStr): self
+    {
+        $this->date = Util::parseDate($dateStr);
+        return $this;
+    }
+
+    public function getPercentage(): float
+    {
+        return $this->percentage;
+    }
+
+    public function setPercentage(float $percentage): self
+    {
+        $this->percentage = $percentage;
+        return $this;
+    }
+
+    public function getCreated(): \DateTimeInterface
+    {
+        return $this->created;
+    }
+
+    public function setCreatedFromString(string $dateTimeStr): self
+    {
+        $this->created = Util::parseDateTime($dateTimeStr);
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getShortname(): string
+    {
+        return $this->shortname;
+    }
+
+    public function setShortname(string $shortname): self
+    {
+        $this->shortname = $shortname;
+        return $this;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function setUser(string $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * @return Account[]
+     */
+    public function getAccounts(): array
+    {
+        return $this->accounts;
+    }
+
+    public function setAccounts(array $accounts): self
+    {
+        Assert::allIsInstanceOf($accounts, Account::class);
+
+        $this->accounts = $accounts;
+        return $this;
+    }
+}

--- a/tests/IntegrationTests/VatCodeIntegrationTest.php
+++ b/tests/IntegrationTests/VatCodeIntegrationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IntegrationTests;
+
+use PhpTwinfield\ApiConnectors\VatCodeApiConnector;
+use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\IntegrationTests\BaseIntegrationTest;
+use PhpTwinfield\Response\Response;
+
+final class VatCodeIntegrationTest extends BaseIntegrationTest
+{
+    /**
+     * @var VatCodeApiConnector
+     */
+    private $vatCodeApiConnector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vatCodeApiConnector = new VatCodeApiConnector($this->connection);
+    }
+
+    public function testGetVatCodeDetailWorks()
+    {
+        $response = Response::fromString(
+            file_get_contents(__DIR__ . '/resources/vatCodeGetResponse.xml')
+        );
+
+        $this->processXmlService
+            ->expects($this->once())
+            ->method("sendDocument")
+            ->with($this->isInstanceOf(\PhpTwinfield\Request\Read\VatCode::class))
+            ->willReturn($response);
+
+        $vatCode = $this->vatCodeApiConnector->get('VH', $this->office);
+
+        $this->assertSame('VH', $vatCode->getCode());
+        $this->assertSame('BTW Hoog', $vatCode->getName());
+        $this->assertSame('VH', $vatCode->getShortName());
+        $this->assertSame('8b16d247-81de-4334-8810-8dcb30386f42', $vatCode->getUID());
+        $this->assertEquals(new \DateTimeImmutable('2004-10-27 10:13:42'), $vatCode->getCreated());
+        $this->assertEquals(new \DateTimeImmutable('2004-10-27 10:13:42'), $vatCode->getModified());
+        $this->assertSame(0, $vatCode->getTouched());
+        $this->assertSame('JDOE', $vatCode->getUser());
+        $this->assertCount(2, $vatCode->getPercentages());
+
+        [$percentage1, $percentage2] = $vatCode->getPercentages();
+
+        $this->assertSame('active', $percentage1->getStatus());
+        $this->assertTrue($percentage1->isInUse());
+        $this->assertEquals(new \DateTimeImmutable('2000-01-01'), $percentage1->getDate());
+        $this->assertSame(19.0, $percentage1->getPercentage());
+        $this->assertEquals(new \DateTimeImmutable('2013-10-02 11:40:36'), $percentage1->getCreated());
+        $this->assertSame('BTW Hoog', $percentage1->getName());
+        $this->assertSame('VH', $percentage1->getShortname());
+        $this->assertSame('JDOE', $percentage1->getUser());
+        $this->assertCount(1, $percentage1->getAccounts());
+
+        [$account] = $percentage1->getAccounts();
+        $this->assertSame('1', $account->getId());
+        $this->assertSame('17120', $account->getDim1());
+        $this->assertSame('NL', $account->getGroupCountry());
+        $this->assertSame('NL1A', $account->getGroup());
+        $this->assertSame(100.0, $account->getPercentage());
+        $this->assertEquals(LineType::VAT(), $account->getLineType());
+
+        $this->assertSame('active', $percentage2->getStatus());
+        $this->assertTrue($percentage2->isInUse());
+        $this->assertEquals(new \DateTimeImmutable('2012-10-01'), $percentage2->getDate());
+        $this->assertSame(21.0, $percentage2->getPercentage());
+        $this->assertEquals(new \DateTimeImmutable('2013-10-02 11:40:36'), $percentage2->getCreated());
+        $this->assertSame('BTW Hoog', $percentage2->getName());
+        $this->assertSame('VH', $percentage2->getShortname());
+        $this->assertSame('JDOE', $percentage2->getUser());
+        $this->assertCount(1, $percentage2->getAccounts());
+
+        [$account] = $percentage2->getAccounts();
+        $this->assertSame('1', $account->getId());
+        $this->assertSame('17120', $account->getDim1());
+        $this->assertSame('NL', $account->getGroupCountry());
+        $this->assertSame('NL1A', $account->getGroup());
+        $this->assertSame(100.0, $account->getPercentage());
+        $this->assertEquals(LineType::VAT(), $account->getLineType());
+    }
+}

--- a/tests/IntegrationTests/resources/vatCodeGetResponse.xml
+++ b/tests/IntegrationTests/resources/vatCodeGetResponse.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<vat status="active" result="1">
+    <code>VH</code>
+    <name>BTW Hoog</name>
+    <shortname>VH</shortname>
+    <uid>8b16d247-81de-4334-8810-8dcb30386f42</uid>
+    <created>20041027101342</created>
+    <modified>20041027101342</modified>
+    <touched>0</touched>
+    <user name="John Doe" shortname="JDoe">JDOE</user>
+    <type>sales</type>
+    <percentages>
+        <percentage status="active" inuse="true">
+            <date>20000101</date>
+            <percentage>19.000000000</percentage>
+            <created>20131002114036</created>
+            <name>BTW Hoog</name>
+            <shortname>VH</shortname>
+            <user name="John Doe" shortname="JDoe">JDOE</user>
+            <discountaccount name="" shortname="" dimensiontype=""/>
+            <writeoffaccount name="" shortname="" dimensiontype=""/>
+            <accounts>
+                <account id="1">
+                    <dim1 name="Af te dragen BTW 21%" shortname="" dimensiontype="BAS">17120</dim1>
+                    <groupcountry name="Nederland" shortname="">NL</groupcountry>
+                    <group name="Leveringen/Diensten belast met hoog %" shortname="L/D Hoog">NL1A</group>
+                    <percentage>100.0</percentage>
+                    <linetype>vat</linetype>
+                </account>
+            </accounts>
+        </percentage>
+        <percentage status="active" inuse="true">
+            <date>20121001</date>
+            <percentage>21.000000000</percentage>
+            <created>20131002114036</created>
+            <name>BTW Hoog</name>
+            <shortname>VH</shortname>
+            <user name="John Doe" shortname="JDoe">JDOE</user>
+            <discountaccount name="" shortname="" dimensiontype=""/>
+            <writeoffaccount name="" shortname="" dimensiontype=""/>
+            <accounts>
+                <account id="1">
+                    <dim1 name="Af te dragen BTW 21%" shortname="" dimensiontype="BAS">17120</dim1>
+                    <groupcountry name="Nederland" shortname="">NL</groupcountry>
+                    <group name="Leveringen/Diensten belast met hoog %" shortname="L/D Hoog">NL1A</group>
+                    <percentage>100.0</percentage>
+                    <linetype>vat</linetype>
+                </account>
+            </accounts>
+        </percentage>
+    </percentages>
+</vat>


### PR DESCRIPTION
For a project I'm working on I need the ability to lookup the VAT percentages. I've tried matching the coding style as much as possible, but it might be off in some places.

Also, I'm not quite sure about the naming I used for the objects as `VatCode` (less detailed) was already used for the `listAll` method on the connector.

Happy to change anything, let me know!
