### PR TITLE
Adding missing element to invoiceSendRequest.xml

### DIFF
--- a/tests/IntegrationTests/resources/invoiceSendRequest.xml
+++ b/tests/IntegrationTests/resources/invoiceSendRequest.xml
@@ -10,6 +10,7 @@
             <currency>EUR</currency>
             <period>2012/8</period>
             <invoicedate>20120831</invoicedate>
+            <paymentmethod>cash</paymentmethod>
             <bank>BNK</bank>
             <invoiceaddressnumber>1</invoiceaddressnumber>
             <deliveraddressnumber>1</deliveraddressnumber>


### PR DESCRIPTION
When preparing a different pull request I noticed an unrelated test was failing. The changes from pull request #206 add the `paymentmethod` element to the `InvoiceDocument`, but the example xml file used in the tests was not updated yet.