### PR TITLE
Allow meansofpayment to be set customers

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -3,6 +3,7 @@
 namespace PhpTwinfield;
 
 use PhpTwinfield\Enums\CollectionSchema;
+use PhpTwinfield\Enums\MeansOfPayment;
 use PhpTwinfield\Transactions\TransactionFields\OfficeField;
 use PhpTwinfield\Transactions\TransactionLineFields\VatCodeField;
 
@@ -47,6 +48,7 @@ class Customer
     private $editDimensionName;
     private $dueDays = 0;
     private $payAvailable = false;
+    private $meansOfPayment;
     private $payCode;
     private $vatCode;
     private $eBilling = false;
@@ -263,6 +265,17 @@ class Customer
     public function setPayAvailable(bool $payAvailable): self
     {
         $this->payAvailable = $payAvailable;
+        return $this;
+    }
+
+    public function getMeansOfPayment(): ?MeansOfPayment
+    {
+        return $this->meansOfPayment;
+    }
+
+    public function setMeansOfPayment(?MeansOfPayment $meansOfPayment): self
+    {
+        $this->meansOfPayment = $meansOfPayment;
         return $this;
     }
 

--- a/src/DomDocuments/CustomersDocument.php
+++ b/src/DomDocuments/CustomersDocument.php
@@ -143,6 +143,13 @@ class CustomersDocument extends BaseDocument
                 $collectionSchemaElement = $this->createElement('collectionschema', $collectionSchema->getValue());
                 $financialElement->appendChild($collectionSchemaElement);
             }
+
+            $meansOfPayment = $customer->getMeansOfPayment();
+
+            if ($meansOfPayment !== null) {
+                $meansOfPaymentElement = $this->createElement('meansofpayment', $meansOfPayment->getValue());
+                $financialElement->appendChild($meansOfPaymentElement);
+            }
         }
 
         //check if creditmanagement should be set

--- a/src/Enums/MeansOfPayment.php
+++ b/src/Enums/MeansOfPayment.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PhpTwinfield\Enums;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static MeansOfPayment NONE()
+ * @method static MeansOfPayment PAYMENTFILE()
+ */
+class MeansOfPayment extends Enum
+{
+    protected const NONE = "none";
+    protected const PAYMENTFILE = "paymentfile";
+}

--- a/tests/IntegrationTests/CustomerIntegrationTest.php
+++ b/tests/IntegrationTests/CustomerIntegrationTest.php
@@ -9,6 +9,7 @@ use PhpTwinfield\CustomerBank;
 use PhpTwinfield\CustomerCollectMandate;
 use PhpTwinfield\DomDocuments\CustomersDocument;
 use PhpTwinfield\Enums\CollectionSchema;
+use PhpTwinfield\Enums\MeansOfPayment;
 use PhpTwinfield\Mappers\CustomerMapper;
 use PhpTwinfield\Office;
 use PhpTwinfield\Response\Response;
@@ -174,6 +175,7 @@ class CustomerIntegrationTest extends BaseIntegrationTest
         $customer->setName('Customer 0');
         $customer->setDueDays('30');
         $customer->setPayAvailable(true);
+        $customer->setMeansOfPayment(MeansOfPayment::PAYMENTFILE());
         $customer->setPayCode('SEPANLDD');
 
         $address = new CustomerAddress();

--- a/tests/IntegrationTests/resources/customerSendRequest.xml
+++ b/tests/IntegrationTests/resources/customerSendRequest.xml
@@ -16,6 +16,7 @@
 				<firstrundate>20180608</firstrundate>
 			</collectmandate>
 			<collectionschema>core</collectionschema>
+			<meansofpayment>paymentfile</meansofpayment>
 		</financials>
 		<addresses>
 			<address type="invoice" default="true">


### PR DESCRIPTION
Looks like I forgot to submit this pull request due to using a fork of the Twinfield library in my own project. My previous pull request (#210) actually relies on the `MeansOfPayment` enum that is included here.