### PR TITLE
Added psr/log version 2.0 || 3.0 to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "moneyphp/money": "^3.0 || ^4.0",
     "myclabs/php-enum": "^1.5",
     "psr/http-message": "^1.0",
-    "psr/log": "^1.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0",
     "webmozart/assert": "^1.2"
   },
   "suggest": {

--- a/tests/UnitTests/ApiConnectors/BaseApiConnectorTest.php
+++ b/tests/UnitTests/ApiConnectors/BaseApiConnectorTest.php
@@ -139,7 +139,7 @@ class BaseApiConnectorTest extends TestCase implements LoggerInterface
      *
      * @inheritdoc
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array()): void
     {
         $this->logs[] = [$level, $message, $context];
     }


### PR DESCRIPTION
In order to support psr/log version 2 & 3 we need to define the versions in composer.json file. Verified that psr/log is backward compatible.