### PR TITLE
Support existing accessToken on OpenIdConnectAuthentication

### DIFF
--- a/tests/UnitTests/Secure/OpenIdConnectionAuthenticationTest.php
+++ b/tests/UnitTests/Secure/OpenIdConnectionAuthenticationTest.php
@@ -2,8 +2,10 @@
 
 namespace PhpTwinfield\UnitTests\Secure;
 
+use Closure;
 use Eloquent\Liberator\Liberator;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use PhpTwinfield\Office;
 use PhpTwinfield\Secure\OpenIdConnectAuthentication;
 use PhpTwinfield\Secure\Provider\InvalidAccessTokenException;
@@ -71,18 +73,21 @@ class OpenIdConnectionAuthenticationTest extends TestCase
             );
 
         $openIdConnect = Liberator::liberate($openIdConnect);
-        $this->assertNull($openIdConnect->accessToken);
+        $this->assertNull($openIdConnect->getAccessToken());
 
         $openIdConnect->login();
 
-        $this->assertEquals("stub", $openIdConnect->accessToken);
+        $this->assertEquals("stub", $openIdConnect->getAccessToken());
         $this->assertEquals("someClusterUrl", $openIdConnect->getCluster());
     }
 
     public function testRefreshAndAccessTokenAreSetLoginSuccess()
     {
         $openIdConnect = $this->getMockBuilder(OpenIdConnectAuthentication::class)
-            ->setConstructorArgs([ $this->openIdProvider, "refresh", null ])
+            ->setConstructorArgs([ $this->openIdProvider, "refresh", null, new AccessToken([
+                'access_token' => 'test',
+                'expires_in' => time() + 1000,
+            ]) ])
             ->setMethods(["validateToken", "refreshToken"])
             ->getMock();
 
@@ -96,7 +101,6 @@ class OpenIdConnectionAuthenticationTest extends TestCase
             ->method("refreshToken");
 
         $openIdConnect = Liberator::liberate($openIdConnect);
-        $openIdConnect->accessToken = "test";
 
         $openIdConnect->login();
 
@@ -121,5 +125,146 @@ class OpenIdConnectionAuthenticationTest extends TestCase
         $openIdConnect->login();
 
         $this->assertEquals("someClusterUrl", $openIdConnect->getCluster());
+    }
+
+    public function testSetAccessToken(): void
+    {
+        $accessTokenMock = $this->createMock(AccessTokenInterface::class);
+        $openIdConnect = new OpenIdConnectAuthentication($this->openIdProvider, 'test');
+
+        $result = $openIdConnect->setAccessToken($accessTokenMock);
+
+        $this->assertEquals($accessTokenMock, $openIdConnect->getAccessToken());
+        $this->assertInstanceOf(OpenIdConnectAuthentication::class, $result);
+    }
+
+    public function testGetAccessTokenSetFromConstructor(): void
+    {
+        $accessTokenMock = $this->createMock(AccessTokenInterface::class);
+        $openIdConnect = new OpenIdConnectAuthentication(
+            $this->openIdProvider,
+            'test',
+            null,
+            $accessTokenMock
+        );
+
+        $this->assertEquals($accessTokenMock, $openIdConnect->getAccessToken());
+    }
+
+    public function testHasAccessToken(): void
+    {
+        $accessTokenMock = $this->createMock(AccessTokenInterface::class);
+        $openIdConnect = new OpenIdConnectAuthentication(
+            $this->openIdProvider,
+            'test',
+            null,
+            $accessTokenMock
+        );
+
+        $this->assertTrue($openIdConnect->hasAccessToken());
+    }
+
+    public function testHasNoAccessToken(): void
+    {
+        $openIdConnect = new OpenIdConnectAuthentication($this->openIdProvider, 'test');
+
+        $this->assertFalse($openIdConnect->hasAccessToken());
+    }
+
+    public function testIsExpiredAccessTokenWithoutToken(): void
+    {
+        $openIdConnect = new OpenIdConnectAuthentication($this->openIdProvider, 'test');
+
+        $openIdConnect = Liberator::liberate($openIdConnect);
+        $result = $openIdConnect->isExpiredAccessToken();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsExpiredAccessTokenWithToken(): void
+    {
+        $accessTokenMock = $this->createMock(AccessTokenInterface::class);
+        $accessTokenMock->expects($this->once())
+            ->method('hasExpired')
+            ->willReturn(true);
+
+        $openIdConnect = new OpenIdConnectAuthentication(
+            $this->openIdProvider,
+            'test',
+            null,
+            $accessTokenMock
+        );
+
+        $openIdConnect = Liberator::liberate($openIdConnect);
+        $result = $openIdConnect->isExpiredAccessToken();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsNotExpired(): void
+    {
+        $accessTokenMock = $this->createMock(AccessTokenInterface::class);
+        $accessTokenMock->expects($this->once())
+            ->method('hasExpired')
+            ->willReturn(false);
+
+        $openIdConnect = new OpenIdConnectAuthentication(
+            $this->openIdProvider,
+            'test',
+            null,
+            $accessTokenMock
+        );
+
+        $openIdConnect = Liberator::liberate($openIdConnect);
+        $result = $openIdConnect->isExpiredAccessToken();
+
+        $this->assertFalse($result);
+    }
+
+    public function testRegisterAfterValidateCallback(): void
+    {
+        $openIdConnect = new OpenIdConnectAuthentication($this->openIdProvider, 'test');
+        $openIdConnect->registerAfterValidateCallback(function() {});
+
+        $openIdConnect = Liberator::liberate($openIdConnect);
+        $callbacks = $openIdConnect->getAfterValidateCallbacks();
+
+        $this->assertCount(1, $callbacks);
+        $this->assertInstanceOf(Closure::class, $callbacks[0]);
+    }
+
+    public function testValidateTokenWithMissingAccessToken(): void
+    {
+        $this->expectException(InvalidAccessTokenException::class);
+
+        $openIdConnect = new OpenIdConnectAuthentication($this->openIdProvider, 'test');
+        $openIdConnect = Liberator::liberate($openIdConnect);
+        $openIdConnect->validateToken();
+    }
+
+    public function testCallAfterValidateCallbacks(): void
+    {
+        $accessToken = $this->createMock(AccessTokenInterface::class);
+
+        $openIdConnect = $this->getMockBuilder(OpenIdConnectAuthentication::class)
+            ->setConstructorArgs([$this->openIdProvider, "refresh", null, $accessToken])
+            ->setMethods(["getValidationResult"])
+            ->getMock();
+        $openIdConnect->expects($this->once())
+            ->method('getValidationResult')
+            ->willReturn(json_encode(['test']));
+
+        $callableMock = $this->getMockBuilder('DoesNotExists')
+            ->setMockClassName('Foo')
+            ->setMethods(['callback'])
+            ->getMock();
+        $callableMock->expects($this->once())
+            ->method('callback')
+            ->with($accessToken);
+
+        $openIdConnect->registerAfterValidateCallback([$callableMock, 'callback']);
+
+        $openIdConnect = Liberator::liberate($openIdConnect);
+        $openIdConnect->validateToken();
     }
 }


### PR DESCRIPTION
Hi, I've created a pull request allowing people to:

1. Setup a connection with an existing access token object
2. Add a custom callback to be called when a token is refresh, to process the token.

There's already a similar idea in: https://github.com/php-twinfield/twinfield/pull/144#issuecomment-1361121363

That PR is fairly old and did not seem to be very active. Also it included some other unrelated improvements, that might makes this hard to merge to master.

The code has some breaking changes in case someone is overriding `src/Secure/OpenIdConnectAuthentication.php` `login()` or `validateToken()`

## Summary of improvements

- Allow setting an AccessToken object, through constructor or setter
  -  This prevents unnecessary token requests in case the access token is valid.
- Only validate the token on login when:
  - The access token is set/replaced
  - The access token is refreshed when it's expired
- Allows to add your own callback, that will be called when the token is validated, I chose this place, because it's at that point validated by Twinfield that the token is valid. The callable will receive the full AccessToken object and can be processed within the application.
  - In my use case I'm updating my client token, so on every subsequent requests within the validity (1 hour) it won't fetch a new token from twinfield, which saves an additional request.

### Previous login flow on every `getAuthenticatedClient()` call
- Get access token
- Validate access token

### New flow
- Has access token
  - Has valid access token
  - Validate access token
- Has no access token -> previous flow
  - Ability to store access token, to continue first flow on subsequent calls.

I've documented the use case in the readme.md file to provide clarity and documentation and wrote tests for this functionality.

Hope this PR can be helpful and if there are questions, don't hesitate to contact me or responding on this PR.

Cheers 
