### PR TITLE
Only skip setting dim1 on transaction lines when the line is of type VAT

### DIFF
--- a/src/DomDocuments/TransactionsDocument.php
+++ b/src/DomDocuments/TransactionsDocument.php
@@ -125,7 +125,8 @@ class TransactionsDocument extends BaseDocument
             $linesElement->appendChild($lineElement);
 
             $dim1 = $transactionLine->getDim1();
-            if (!empty($dim1)) {
+            $isVatLine = $transactionLine->getLineType()->equals(LineType::VAT());
+            if (!$isVatLine || !empty($dim1)) {
                 $dim1Element = $this->createNodeWithTextContent('dim1', $dim1);
                 $lineElement->appendChild($dim1Element);
             }

--- a/tests/UnitTests/DomDocuments/TransactionsDocumentUnitTest.php
+++ b/tests/UnitTests/DomDocuments/TransactionsDocumentUnitTest.php
@@ -70,14 +70,14 @@ final class TransactionsDocumentUnitTest extends TestCase
         $totalLine
             ->setLineType(LineType::TOTAL())
             ->setId(1)
-            ->setDim1('1002')
+            ->setDim1('')
             ->setValue(Money::EUR(12100));
 
         $detailLine = new CashTransactionLine();
         $detailLine
             ->setLineType(LineType::DETAIL())
             ->setId(2)
-            ->setDim1('1300')
+            ->setDim1('')
             ->setDim2('1000')
             ->setValue(Money::EUR(10000))
             ->setVatCode('VH')
@@ -113,7 +113,7 @@ final class TransactionsDocumentUnitTest extends TestCase
         $detailLine
             ->setLineType(LineType::DETAIL())
             ->setId(2)
-            ->setDim1('1300')
+            ->setDim1('')
             ->setDim2('1000')
             ->setValue(Money::EUR(10000))
             ->setVatCode('VH')
@@ -153,7 +153,7 @@ final class TransactionsDocumentUnitTest extends TestCase
         $totalLine
             ->setLineType(LineType::TOTAL())
             ->setId(1)
-            ->setDim1('1600')
+            ->setDim1('')
             ->setDim2('2000')
             ->setValue(Money::EUR(12100))
             ->setDescription('');
@@ -162,7 +162,7 @@ final class TransactionsDocumentUnitTest extends TestCase
         $detailLine
             ->setLineType(LineType::DETAIL())
             ->setId(2)
-            ->setDim1('8020')
+            ->setDim1('')
             ->setValue(Money::EUR(10000))
             ->setDescription('Outfit')
             ->setVatCode('IH');
@@ -200,7 +200,7 @@ final class TransactionsDocumentUnitTest extends TestCase
         $totalLine
             ->setLineType(LineType::TOTAL())
             ->setId(1)
-            ->setDim1('1300')
+            ->setDim1('')
             ->setDim2('1000')
             ->setValue(Money::EUR(12100))
             ->setDescription('');
@@ -209,7 +209,7 @@ final class TransactionsDocumentUnitTest extends TestCase
         $detailLine
             ->setLineType(LineType::DETAIL())
             ->setId(2)
-            ->setDim1('8020')
+            ->setDim1('')
             ->setValue(Money::EUR(10000))
             ->setDescription('Outfit')
             ->setVatCode('VH');


### PR DESCRIPTION
Fixes the issue as described by @edwin-easytrans in https://github.com/php-twinfield/twinfield/pull/199#issuecomment-1474785075 by limiting the scope of the earlier change to only apply to VAT lines.