### PR TITLE
Add support for matches field on transactions

### DIFF
--- a/src/BaseTransactionLine.php
+++ b/src/BaseTransactionLine.php
@@ -4,6 +4,7 @@ namespace PhpTwinfield;
 
 use Money\Money;
 use PhpTwinfield\Enums\LineType;
+use PhpTwinfield\Transactions\MatchSet;
 use PhpTwinfield\Transactions\TransactionLine;
 use PhpTwinfield\Transactions\TransactionLineFields\CommentField;
 use PhpTwinfield\Transactions\TransactionLineFields\FreeCharField;
@@ -18,7 +19,7 @@ use PhpTwinfield\Transactions\TransactionLineFields\VatTurnoverFields;
  * @todo $vatRepValue Only if line type is detail. VAT amount in reporting currency.
  * @todo $destOffice Office code. Used for inter company transactions.
  * @todo $comment Comment set on the transaction line.
- * @todo $matches Contains matching information. Read-only attribute.
+ * @todo $matches Implement for BankTransactionLine
  *
  * @link https://accounting.twinfield.com/webservices/documentation/#/ApiReference/Transactions/BankTransactions
  */
@@ -116,6 +117,11 @@ abstract class BaseTransactionLine implements TransactionLine
      *                              bank book is set to Allowed or Mandatory.
      */
     protected $currencyDate;
+
+    /**
+     * @var MatchSet[] Empty if not available, readonly.
+     */
+    protected $matches = [];
 
     public function getLineType(): LineType
     {
@@ -413,5 +419,18 @@ abstract class BaseTransactionLine implements TransactionLine
             $transaction->getNumber(),
             $this->getId()
         );
+    }
+
+    public function addMatch(MatchSet $match)
+    {
+        $this->matches[] = $match;
+    }
+
+    /**
+     * @return MatchSet[]
+     */
+    public function getMatches(): array
+    {
+        return $this->matches;
     }
 }

--- a/src/Transactions/MatchLine.php
+++ b/src/Transactions/MatchLine.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PhpTwinfield\Transactions;
+
+use Money\Money;
+
+class MatchLine
+{
+    /** @var string */
+    private $code;
+
+    /** @var int */
+    private $number;
+
+    /** @var int */
+    private $line;
+
+    /** @var Money */
+    private $matchValue;
+
+    public function __construct(
+        string $code,
+        int $number,
+        int $line,
+        Money $matchValue
+    )
+    {
+        $this->code = $code;
+        $this->number = $number;
+        $this->line = $line;
+        $this->matchValue = $matchValue;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getNumber(): int
+    {
+        return $this->number;
+    }
+
+    public function getLine(): int
+    {
+        return $this->line;
+    }
+
+    public function getMatchValue(): Money
+    {
+        return $this->matchValue;
+    }
+}

--- a/src/Transactions/MatchSet.php
+++ b/src/Transactions/MatchSet.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PhpTwinfield\Transactions;
+
+use DateTimeInterface;
+use Money\Money;
+use PhpTwinfield\Enums\Destiny;
+
+class MatchSet
+{
+    /** @var Destiny */
+    private $status;
+
+    /** @var DateTimeInterface */
+    private $matchDate;
+
+    /** @var Money */
+    private $matchValue;
+
+    /** @var MatchLine[] */
+    private $matchLines;
+
+    /**
+     * @param Destiny $status
+     * @param DateTimeInterface $matchDate
+     * @param Money $matchValue
+     * @param MatchLine[] $matchLines
+     */
+    public function __construct(
+        Destiny $status,
+        DateTimeInterface $matchDate,
+        Money $matchValue,
+        array $matchLines
+    )
+    {
+        $this->status = $status;
+        $this->matchDate = $matchDate;
+        $this->matchValue = $matchValue;
+        $this->matchLines = $matchLines;
+    }
+
+    public function getStatus(): Destiny
+    {
+        return $this->status;
+    }
+
+    public function getMatchDate(): DateTimeInterface
+    {
+        return $this->matchDate;
+    }
+
+    public function getMatchValue(): Money
+    {
+        return $this->matchValue;
+    }
+
+    /**
+     * @return MatchLine[]
+     */
+    public function getMatchLines(): array
+    {
+        return $this->matchLines;
+    }
+}

--- a/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
+++ b/tests/IntegrationTests/PurchaseTransactionIntegrationTest.php
@@ -85,12 +85,12 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertSame('', $totalLine->getDescription());
         $this->assertSame(PurchaseTransactionLine::MATCHSTATUS_AVAILABLE, $totalLine->getMatchStatus());
         $this->assertSame(2, $totalLine->getMatchLevel());
-        $this->assertEquals(Money::EUR(12100), $totalLine->getBaseValueOpen());
+        $this->assertEquals(Money::EUR(12000), $totalLine->getBaseValueOpen());
         $this->assertNull($totalLine->getVatCode());
         $this->assertNull($totalLine->getVatValue());
         $this->assertEquals(Money::EUR(2100), $totalLine->getVatTotal());
         $this->assertEquals(Money::EUR(2100), $totalLine->getVatBaseTotal());
-        $this->assertEquals(Money::EUR(12100), $totalLine->getValueOpen());
+        $this->assertEquals(Money::EUR(12000), $totalLine->getValueOpen());
         $this->assertEquals(new DateTime('2020-12-03'), $totalLine->getMatchDate());
 
         $this->assertEquals(LineType::DETAIL(), $detailLine->getLineType());
@@ -134,6 +134,20 @@ class PurchaseTransactionIntegrationTest extends BaseIntegrationTest
         $this->assertNull($vatLine->getVatBaseTotal());
         $this->assertNull($vatLine->getValueOpen());
         $this->assertNull($vatLine->getMatchDate());
+
+        $matches = $totalLine->getMatches();
+        $this->assertCount(1, $matches);
+        $match = $matches[0];
+        $this->assertEquals(Destiny::TEMPORARY(), $match->getStatus());
+        $this->assertEquals(new DateTime('2020-12-03'), $match->getMatchDate());
+        $this->assertEquals(Money::EUR(100), $match->getMatchValue());
+        $matchLines = $match->getMatchLines();
+        $this->assertCount(1, $matchLines);
+        $matchLine = $matchLines[0];
+        $this->assertEquals('BNK', $matchLine->getCode());
+        $this->assertEquals('201300022', $matchLine->getNumber());
+        $this->assertEquals(1, $matchLine->getLine());
+        $this->assertEquals(Money::EUR(-100), $matchLine->getMatchValue());
     }
 
     public function testSendPurchaseTransactionWorks()

--- a/tests/IntegrationTests/resources/purchaseTransactionGetResponse.xml
+++ b/tests/IntegrationTests/resources/purchaseTransactionGetResponse.xml
@@ -27,11 +27,26 @@
             <vatbasetotal>21.00</vatbasetotal>
             <matchlevel>2</matchlevel>
             <customersupplier>2</customersupplier>
-            <openvalue>121.00</openvalue>
-            <openbasevalue>121.00</openbasevalue>
-            <openrepvalue>156.53</openrepvalue>
+            <openvalue>120.00</openvalue>
+            <openbasevalue>120.00</openbasevalue>
+            <openrepvalue>155.23</openrepvalue>
             <matchstatus>available</matchstatus>
             <matchdate>20201203</matchdate>
+            <matches>
+                <set status="temporary">
+                    <matchdate>20201203</matchdate>
+                    <lines>
+                        <line>
+                            <code>BNK</code>
+                            <number>201300022</number>
+                            <line>1</line>
+                            <method>payment</method>
+                            <matchvalue>-1.00</matchvalue>
+                        </line>
+                    </lines>
+                    <matchvalue>1.00</matchvalue>
+                </set>
+            </matches>
         </line>
         <line type="detail" id="2">
             <dim1 name="Omzet (19%)" shortname="Omzet (19%)" type="PNL" inuse="true" vatcode="" vatobligatory="false">8020</dim1>


### PR DESCRIPTION
This includes all types of transactions except for banktransactions
Bump supported PHP version to 8.0
Fix a bunch of deprecated warnings in tests
Bump eloquent/liberate library to 3.0 version to support php 8.2