### PR TITLE
Fix more Project salestransactionline issues

### DIFF
--- a/src/SalesTransactionLine.php
+++ b/src/SalesTransactionLine.php
@@ -126,7 +126,7 @@ class SalesTransactionLine extends BaseTransactionLine
     {
         if (
             $matchStatus !== null &&
-            $this->getLineType() === LineType::VAT() &&
+            $this->getLineType()->equals(LineType::VAT()) &&
             $matchStatus != self::MATCHSTATUS_NOTMATCHABLE
         ) {
             throw Exception::invalidMatchStatusForLineType($matchStatus, $this);
@@ -144,7 +144,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setMatchLevel(?int $matchLevel): BaseTransactionLine
     {
-        if ($matchLevel !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
+        if ($matchLevel !== null && $this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidFieldForLineType('matchLevel', $this);
         }
 
@@ -160,7 +160,7 @@ class SalesTransactionLine extends BaseTransactionLine
      */
     public function setBaseValueOpen(?Money $baseValueOpen): BaseTransactionLine
     {
-        if ($baseValueOpen !== null && !$this->getLineType()->equals(LineType::TOTAL())) {
+        if ($baseValueOpen !== null && $this->getLineType()->equals(LineType::VAT())) {
             throw Exception::invalidFieldForLineType('baseValueOpen', $this);
         }
 


### PR DESCRIPTION
Apparently all fields on salestransactionline that are listed in the documentation as 'total' only, can also be set on 'detail' if the line has a project.