### PR TITLE
Map vat code and allow remove invoice line

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -63,6 +63,12 @@ class Invoice
         return $this;
     }
 
+    public function removeLine(InvoiceLine $line)
+    {
+        unset($this->lines[$line->getID()]);
+        return $this;
+    }
+
     /**
      * @return InvoiceLine[]
      */

--- a/src/Mappers/InvoiceMapper.php
+++ b/src/Mappers/InvoiceMapper.php
@@ -91,6 +91,7 @@ class InvoiceMapper extends BaseMapper
             'performancedate'        => 'setPerformanceDate',
             'performancetype'        => 'setPerformanceType',
             'dim1'                   => 'setDim1',
+            'vatcode'                => 'setVatCode',
         );
 
         /** @var \DOMElement $lineDOM */

--- a/tests/IntegrationTests/InvoiceIntegrationTest.php
+++ b/tests/IntegrationTests/InvoiceIntegrationTest.php
@@ -79,6 +79,7 @@ class InvoiceIntegrationTest extends BaseIntegrationTest
         $this->assertSame('15.00', $invoiceLine->getValueInc());
         $this->assertSame('15.00', $invoiceLine->getUnitsPriceExcl());
         $this->assertSame('8020', $invoiceLine->getDim1());
+        $this->assertSame('VN', $invoiceLine->getVatCode());
 
         // TODO - Vat lines
 


### PR DESCRIPTION
This pull request adds the following functionalities

- The ability to remove a invoice line
- The vat code will now be filled when a invoice is retrieved from Twinfield
