### PR TITLE
Loosen `psr/http-message` version to allow `^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "ext-soap": "*",
     "moneyphp/money": "^3.0 || ^4.0",
     "myclabs/php-enum": "^1.5",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
     "webmozart/assert": "^1.2"
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,46 @@
 parameters:
 	ignoreErrors:
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:eof\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:getContents\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:getSize\\(\\) should return int\\|null but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:isReadable\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:isSeekable\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:isWritable\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:read\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:tell\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php
+
+		-
+			message: "#^Method Dummy\\\\StringStream\\:\\:write\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: tests/Dummy/StringStream.php

--- a/tests/Dummy/StringStream.php
+++ b/tests/Dummy/StringStream.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dummy;
+
+use Psr\Http\Message\StreamInterface;
+
+final class StringStream implements StreamInterface
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function close(): void
+    {
+    }
+
+    public function detach()
+    {
+    }
+
+    public function getSize(): ?int
+    {
+    }
+
+    public function tell(): int
+    {
+    }
+
+    public function eof(): bool
+    {
+    }
+
+    public function isSeekable(): bool
+    {
+    }
+
+    public function seek(int $offset, int $whence = SEEK_SET): void
+    {
+    }
+
+    public function rewind(): void
+    {
+    }
+
+    public function isWritable(): bool
+    {
+    }
+
+    public function write(string $string): int
+    {
+    }
+
+    public function isReadable(): bool
+    {
+    }
+
+    public function read(int $length): string
+    {
+    }
+
+    public function getContents(): string
+    {
+    }
+
+    public function getMetadata(?string $key = null)
+    {
+    }
+}

--- a/tests/UnitTests/Secure/Provider/OAuthProviderTest.php
+++ b/tests/UnitTests/Secure/Provider/OAuthProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpTwinfield\Secure\Provider;
 
+use Dummy\StringStream;
 use GuzzleHttp\ClientInterface;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
@@ -77,7 +78,7 @@ class OAuthProviderTest extends TestCase
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->any())
             ->method("getBody")
-            ->willReturn('{"access_token":"mock_access_token", "token_type":"bearer"}');
+            ->willReturn(new StringStream('{"access_token":"mock_access_token", "token_type":"bearer"}'));
         $response->expects($this->any())
             ->method("getHeader")
             ->willReturn(['content-type' => 'json']);
@@ -102,7 +103,7 @@ class OAuthProviderTest extends TestCase
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->any())
             ->method("getBody")
-            ->willReturn('{"error":{"type":"request","message":"someErrorMessage"}}');
+            ->willReturn(new StringStream('{"error":{"type":"request","message":"someErrorMessage"}}'));
         $response->expects($this->any())
             ->method("getHeader")
             ->willReturn(['content-type' => 'json']);
@@ -125,7 +126,7 @@ class OAuthProviderTest extends TestCase
         $response = $this->createMock(ResponseInterface::class);
         $response->expects($this->any())
             ->method("getBody")
-            ->willReturn('{"sub": "someId", "twf.organisationId": "someOrganisationId"}');
+            ->willReturn(new StringStream('{"sub": "someId", "twf.organisationId": "someOrganisationId"}'));
         $response->expects($this->any())
             ->method("getHeader")
             ->willReturn(['content-type' => 'json']);


### PR DESCRIPTION
By loosening the constraints consumers will be able to upgrade their `psr/http-message` constraints too.

This change is untested ❗ 