### PR TITLE
Fix: added empty string instead of null

### DIFF
--- a/src/DomDocuments/ArticlesDocument.php
+++ b/src/DomDocuments/ArticlesDocument.php
@@ -85,7 +85,7 @@ class ArticlesDocument extends \DOMDocument
             if (is_bool($nodeValue)) {
                 $nodeValue = ($nodeValue) ? 'true' : 'false';
             }
-            $node = $this->createTextNode($nodeValue);
+            $node = $this->createTextNode($nodeValue ?? '');
 
             // Make the actual element and assign the node
             $element = $this->createElement($tag);
@@ -138,7 +138,7 @@ class ArticlesDocument extends \DOMDocument
                 // Go through each line element and use the assigned method
                 foreach ($lineTags as $tag => $method) {
                     // Make the text node for the method value
-                    $node = $this->createTextNode($line->$method());
+                    $node = $this->createTextNode($line->$method() ?? '');
 
                     // Make the actual element and assign the text node
                     $element = $this->createElement($tag);

--- a/src/DomDocuments/CustomersDocument.php
+++ b/src/DomDocuments/CustomersDocument.php
@@ -60,7 +60,7 @@ class CustomersDocument extends BaseDocument
 
             if($value = $customer->$method()) {
                 // Make text node for method value
-                $node = $this->createTextNode($value);
+                $node = $this->createTextNode($value  ?? '');
 
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
@@ -96,7 +96,7 @@ class CustomersDocument extends BaseDocument
                 if (is_bool($nodeValue)) {
                     $nodeValue = ($nodeValue) ? 'true' : 'false';
                 }
-                $node = $this->createTextNode($nodeValue);
+                $node = $this->createTextNode($nodeValue  ?? '');
 
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
@@ -126,7 +126,7 @@ class CustomersDocument extends BaseDocument
                 foreach ($collectMandateTags as $tag => $method) {
 
                     // Make the text node for the method value
-                    $node = $this->createTextNode($this->getValueFromCallback([$collectMandate, $method]));
+                    $node = $this->createTextNode($this->getValueFromCallback([$collectMandate, $method])  ?? '');
 
                     // Make the actual element and assign the node
                     $element = $this->createElement($tag);
@@ -179,7 +179,7 @@ class CustomersDocument extends BaseDocument
                 if (is_bool($nodeValue)) {
                     $nodeValue = ($nodeValue) ? 'true' : 'false';
                 }
-                $node = $this->createTextNode($nodeValue);
+                $node = $this->createTextNode($nodeValue  ?? '');
 
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
@@ -231,7 +231,7 @@ class CustomersDocument extends BaseDocument
                 foreach ($addressTags as $tag => $method) {
 
                     // Make the text node for the method value
-                    $node = $this->createTextNode($address->$method());
+                    $node = $this->createTextNode($address->$method()  ?? '');
 
                     // Make the actual element and assign the text node
                     $element = $this->createElement($tag);
@@ -279,7 +279,7 @@ class CustomersDocument extends BaseDocument
                 foreach ($bankTags as $tag => $method) {
 
                     // Make the text node for the method value
-                    $node = $this->createTextNode($bank->$method());
+                    $node = $this->createTextNode($bank->$method()  ?? '');
 
                     // Make the actual element and assign the text node
                     $element = $this->createElement($tag);
@@ -292,8 +292,8 @@ class CustomersDocument extends BaseDocument
                 // Bank address fields
 
                 // Make the text nodes for the bank address fields
-                $field2Node = $this->createTextNode($bank->getAddressField2());
-                $field3Node = $this->createTextNode($bank->getAddressField3());
+                $field2Node = $this->createTextNode($bank->getAddressField2()  ?? '');
+                $field3Node = $this->createTextNode($bank->getAddressField3()  ?? '');
 
                 // Make the actual elements and assign the text nodes
                 $field2Element = $this->createElement('field2');

--- a/src/DomDocuments/InvoicesDocument.php
+++ b/src/DomDocuments/InvoicesDocument.php
@@ -48,7 +48,7 @@ class InvoicesDocument extends BaseDocument
         $customer = $invoice->getCustomer();
 
         // <customer>
-        $customerNode    = $this->createTextNode($customer->getCode());
+        $customerNode    = $this->createTextNode($customer->getCode()  ?? '');
         $customerElement = $this->createElement('customer');
         $customerElement->appendChild($customerNode);
         $headerElement->appendChild($customerElement);
@@ -78,7 +78,7 @@ class InvoicesDocument extends BaseDocument
     
             if(null !== $value) {
                 // Make text node for method value
-                $node = $this->createTextNode($value);
+                $node = $this->createTextNode($value  ?? '');
     
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
@@ -122,7 +122,7 @@ class InvoicesDocument extends BaseDocument
             foreach ($lineTags as $tag => $method) {
                 
                 // Make text node for method value
-                $node = $this->createTextNode($this->getValueFromCallback([$line, $method]));
+                $node = $this->createTextNode($this->getValueFromCallback([$line, $method])  ?? '');
 
                 if ($node->textContent === "") {
                     continue;

--- a/src/DomDocuments/SuppliersDocument.php
+++ b/src/DomDocuments/SuppliersDocument.php
@@ -72,7 +72,7 @@ class SuppliersDocument extends \DOMDocument
         foreach ($supplierTags as $tag => $method) {
 
             // Make text node for method value
-            $node = $this->createTextNode($supplier->$method());
+            $node = $this->createTextNode($supplier->$method()  ?? '');
 
             // Make the actual element and assign the node
             $element = $this->createElement($tag);
@@ -107,7 +107,7 @@ class SuppliersDocument extends \DOMDocument
                 if (is_bool($nodeValue)) {
                     $nodeValue = ($nodeValue) ? 'true' : 'false';
                 }
-                $node = $this->createTextNode($nodeValue);
+                $node = $this->createTextNode($nodeValue  ?? '');
 
                 // Make the actual element and assign the node
                 $element = $this->createElement($tag);
@@ -165,7 +165,7 @@ class SuppliersDocument extends \DOMDocument
                 foreach ($addressTags as $tag => $method) {
 
                     // Make the text node for the method value
-                    $node = $this->createTextNode($address->$method());
+                    $node = $this->createTextNode($address->$method()  ?? '');
 
                     // Make the actual element and assign the text node
                     $element = $this->createElement($tag);
@@ -212,7 +212,7 @@ class SuppliersDocument extends \DOMDocument
                 foreach ($bankTags as $tag => $method) {
 
                     // Make the text node for the method value
-                    $node = $this->createTextNode($bank->$method());
+                    $node = $this->createTextNode($bank->$method()  ?? '');
 
                     // Make the actual element and assign the text node
                     $element = $this->createElement($tag);
@@ -225,8 +225,8 @@ class SuppliersDocument extends \DOMDocument
                 // Bank address fields
 
                 // Make the text nodes for the bank address fields
-                $field2Node = $this->createTextNode($bank->getAddressField2());
-                $field3Node = $this->createTextNode($bank->getAddressField3());
+                $field2Node = $this->createTextNode($bank->getAddressField2()  ?? '');
+                $field3Node = $this->createTextNode($bank->getAddressField3()  ?? '');
 
                 // Make the actual elements and assign the text nodes
                 $field2Element = $this->createElement('field2');

--- a/src/DomDocuments/TransactionsDocument.php
+++ b/src/DomDocuments/TransactionsDocument.php
@@ -234,7 +234,7 @@ class TransactionsDocument extends BaseDocument
             }
 
             if ($transactionLine->getDescription() !== null) {
-                $descriptionNode = $this->createTextNode($transactionLine->getDescription());
+                $descriptionNode = $this->createTextNode($transactionLine->getDescription()  ?? '');
                 $descriptionElement = $this->createElement('description');
                 $descriptionElement->appendChild($descriptionNode);
                 $lineElement->appendChild($descriptionElement);


### PR DESCRIPTION
Fix for messages:

Deprecated: DOMDocument::createTextNode(): Passing null to parameter #1 ($data) of type string is deprecated