### PR TITLE
Fix implicitly null deprecation

### DIFF
--- a/src/MatchLine.php
+++ b/src/MatchLine.php
@@ -49,7 +49,7 @@ class MatchLine
      * If you want to add a write off, add it manually with setWriteOff(). Pass $value for partial matching.
      * @see setWriteOff()
      */
-    public static function addToMatchSet(MatchSet $set, MatchReferenceInterface $reference, Money $value = null): self
+    public static function addToMatchSet(MatchSet $set, MatchReferenceInterface $reference, ?Money $value = null): self
     {
         Assert::eq($set->getOffice(), $reference->getOffice());
 

--- a/src/Request/Catalog/Dimension.php
+++ b/src/Request/Catalog/Dimension.php
@@ -24,7 +24,7 @@ class Dimension extends Catalog
      * @param Office|null $office
      * @param string|null $dimType
      */
-    public function __construct(Office $office = null, $dimType = null)
+    public function __construct(?Office $office = null, $dimType = null)
     {
         parent::__construct();
 

--- a/src/Request/Read/BrowseDefinition.php
+++ b/src/Request/Read/BrowseDefinition.php
@@ -12,7 +12,7 @@ class BrowseDefinition extends Read
      * @param string $code
      * @param Office|null $office
      */
-    public function __construct(string $code, Office $office = null)
+    public function __construct(string $code, ?Office $office = null)
     {
         parent::__construct();
 

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -22,7 +22,7 @@ abstract class BaseService extends \SoapClient
      * @param string|null $wsdl    Note you should always pass null as the first argument, the WSDL will be overridden.
      * @param array       $options
      */
-    public function __construct(string $wsdl = null, array $options = [])
+    public function __construct(?string $wsdl = null, array $options = [])
     {
         /*
          * Relies heavily on __getLastResponse() etc.

--- a/src/Services/SessionService.php
+++ b/src/Services/SessionService.php
@@ -15,7 +15,7 @@ class SessionService extends BaseService {
      * @param string|null $wsdl
      * @param array $options
      */
-    public function __construct(string $wsdl = null, array $options = [])
+    public function __construct(?string $wsdl = null, array $options = [])
     {
         // If no cluster is set, it means we're dealing with a login call
         // Hence we set the cluster to use the authentication url


### PR DESCRIPTION
> Implicitly nullable parameter types are now deprecated. - https://www.php.net/releases/8.4/en.php