### PR TITLE
Allow postingrules element and children to the sendDocument call for a customer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -328,6 +328,28 @@ support for another resource.
 
 * [Twinfield API Documentation site](https://accounting.twinfield.com/webservices/documentation/)
 
+## Development
+
+Clone the repository:
+
+```bash
+git clone git@github.com:php-twinfield/twinfield.git
+# navigate to cloned repository
+cd twinfield
+```
+
+To set up the development environment, run:
+
+```bash
+composer install
+```
+
+To run the tests, use:
+
+```bash
+vendor/bin/phpunit
+```
+
 
 ## Authors
 

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -58,6 +58,7 @@ class Customer
     private $creditManagement;
     private $addresses = array();
     private $banks = array();
+    private $postingRules = array();
     private $groups;
 
     public function getCode()
@@ -389,6 +390,27 @@ class Customer
     {
         if (array_key_exists($index, $this->banks)) {
             unset($this->banks[$index]);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function getPostingRules()
+    {
+        return $this->postingRules;
+    }
+
+    public function addPostingRule(CustomerPostingRule $postingrule)
+    {
+        $this->postingRules[$postingrule->getID()] = $postingrule;
+        return $this;
+    }
+
+    public function removePostingRule($index)
+    {
+        if (array_key_exists($index, $this->postingRules)) {
+            unset($this->postingRules[$index]);
             return true;
         } else {
             return false;

--- a/src/CustomerPostingRule.php
+++ b/src/CustomerPostingRule.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace PhpTwinfield;
+
+use Money\Currency;
+
+class CustomerPostingRule
+{
+    private $id;
+    private $status;
+    private $currency;
+    private $amount;
+    private $description;
+    private $lines = [];
+
+    public function getID()
+    {
+        return $this->id;
+    }
+
+    public function setID($id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(?Currency $currency): self
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    public function setAmount($amount): self
+    {
+        $this->amount = $amount;
+        return $this;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function setDescription($description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getLines()
+    {
+        return $this->lines;
+    }
+
+    public function addLine($line): self
+    {
+        $this->lines[] = $line;
+        return $this;
+    }
+
+    public function removeLine($index): bool
+    {
+        if (array_key_exists($index, $this->lines)) {
+            unset($this->lines[$index]);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/src/Customers/Line.php
+++ b/src/Customers/Line.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace PhpTwinfield\Customers;
+
+class Line
+{
+    private $office;
+    private $dimension1;
+    private $dimension2;
+    private $dimension3;
+    private $ratio;
+    private $vatCode;
+    private $description;
+
+    public function getOffice()
+    {
+        return $this->office;
+    }
+
+    public function setOffice($office): self
+    {
+        $this->office = $office;
+        return $this;
+    }
+
+    public function getDimension1()
+    {
+        return $this->dimension1;
+    }
+
+    public function setDimension1($dimension1): self
+    {
+        $this->dimension1 = $dimension1;
+        return $this;
+    }
+
+    public function getDimension2()
+    {
+        return $this->dimension2;
+    }
+
+    public function setDimension2($dimension2): self
+    {
+        $this->dimension2 = $dimension2;
+        return $this;
+    }
+
+    public function getDimension3()
+    {
+        return $this->dimension3;
+    }
+
+    public function setDimension3($dimension3): self
+    {
+        $this->dimension3 = $dimension3;
+        return $this;
+    }
+
+    public function getRatio()
+    {
+        return $this->ratio;
+    }
+
+    public function setRatio($ratio): self
+    {
+        $this->ratio = $ratio;
+        return $this;
+    }
+
+    public function getVatCode()
+    {
+        return $this->vatCode;
+    }
+
+    public function setVatCode($vatCode): self
+    {
+        $this->vatCode = $vatCode;
+        return $this;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function setDescription($description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+}

--- a/src/DomDocuments/CustomersDocument.php
+++ b/src/DomDocuments/CustomersDocument.php
@@ -309,6 +309,73 @@ class CustomersDocument extends BaseDocument
             }
         }
 
+        $postingRules = $customer->getPostingRules();
+        if (!empty($postingRules)) {
+            $postingrulesElement = $this->createElement('postingrules');
+            $customerEl->appendChild($postingrulesElement);
+
+            foreach ($postingRules as $postingRule) {
+                $postingRuleElement = $this->createElement('postingrule');
+                $postingrulesElement->appendChild($postingRuleElement);
+
+                $postingRuleElement->setAttribute("id", $postingRule->getID());
+                $postingRuleElement->setAttribute("status", $postingRule->getStatus());
+
+                $postingRuleTags = array(
+                    'currency'      => 'getCurrency',
+                    'amount'        => 'getAmount',
+                    'description'   => 'getDescription',
+                );
+
+                foreach ($postingRuleTags as $tag => $method) {
+
+                    // Make the text node for the method value
+                    $node = $this->createTextNode($postingRule->$method()  ?? '');
+
+                    // Make the actual element and assign the text node
+                    $element = $this->createElement($tag);
+                    $element->appendChild($node);
+
+                    // Add the completed element
+                    $postingRuleElement->appendChild($element);
+                }
+
+                $lines = $postingRule->getLines();
+                if (!empty($lines)) {
+                    $linesElement = $this->createElement('lines');
+                    $postingRuleElement->appendChild($linesElement);
+
+                    foreach ($lines as $line) {
+                        $lineElement = $this->createElement('line');
+                        $linesElement->appendChild($lineElement);
+
+                        $lineTags = array(
+                            'office' => 'getOffice',
+                            'dimension1' => 'getDimension1',
+                            'dimension2' => 'getDimension2',
+                            'dimension3' => 'getDimension3',
+                            'ratio' => 'getRatio',
+                            'vatcode' => 'getVatCode',
+                            'description' => 'getDescription',
+                        );
+
+                        foreach ($lineTags as $tag => $method) {
+
+                            // Make the text node for the method value
+                            $node = $this->createTextNode($line->$method()  ?? '');
+
+                            // Make the actual element and assign the text node
+                            $element = $this->createElement($tag);
+                            $element->appendChild($node);
+
+                            // Add the completed element
+                            $lineElement->appendChild($element);
+                        }
+                    }
+                }
+            }
+        }
+
         $this->rootElement->appendChild($customerEl);
     }
 }

--- a/tests/IntegrationTests/CustomerIntegrationTest.php
+++ b/tests/IntegrationTests/CustomerIntegrationTest.php
@@ -2,11 +2,14 @@
 
 namespace PhpTwinfield\IntegrationTests;
 
+use Money\Currency;
 use PhpTwinfield\ApiConnectors\CustomerApiConnector;
 use PhpTwinfield\Customer;
 use PhpTwinfield\CustomerAddress;
 use PhpTwinfield\CustomerBank;
 use PhpTwinfield\CustomerCollectMandate;
+use PhpTwinfield\CustomerPostingRule;
+use PhpTwinfield\Customers\Line;
 use PhpTwinfield\DomDocuments\CustomersDocument;
 use PhpTwinfield\Enums\CollectionSchema;
 use PhpTwinfield\Enums\MeansOfPayment;
@@ -217,6 +220,15 @@ class CustomerIntegrationTest extends BaseIntegrationTest
         $customer->setCollectMandate($collectMandate);
 
         $customer->setCollectionSchema(CollectionSchema::CORE());
+
+        $rule = new CustomerPostingRule();
+        $rule->setID(1);
+        $rule->setStatus('active');
+        $rule->setCurrency(new Currency('EUR'));
+        $line = new Line();
+        $line->setDimension1(1300);
+        $rule->addLine($line);
+        $customer->addPostingRule($rule);
 
         $this->processXmlService
             ->expects($this->once())

--- a/tests/IntegrationTests/resources/customerSendRequest.xml
+++ b/tests/IntegrationTests/resources/customerSendRequest.xml
@@ -54,5 +54,23 @@
 				</address>
 			</bank>
 		</banks>
+        <postingrules>
+            <postingrule id="1" status="active">
+                <currency>EUR</currency>
+                <amount></amount>
+                <description></description>
+                <lines>
+                    <line>
+                        <office></office>
+                        <dimension1>1300</dimension1>
+                        <dimension2></dimension2>
+                        <dimension3></dimension3>
+                        <ratio></ratio>
+                        <vatcode></vatcode>
+                        <description></description>
+                    </line>
+                </lines>
+            </postingrule>
+        </postingrules>
 	</dimension>
 </dimensions>


### PR DESCRIPTION
**Feature**
Adds the postingrules to the sendDocument call for a customer by
- adding the appropriate models (e.g. CustomerPostingRule + Line)
- adding getters and setters on the Customer model
- adding additions to the CustomerDocument class to render them

**Bonus**
- Adds some development instructions